### PR TITLE
Исправить автоматическую релизную проверку 0.3.14

### DIFF
--- a/Release-NeAntik.command
+++ b/Release-NeAntik.command
@@ -20,7 +20,7 @@ if [[ ! -x "$RELEASE_SCRIPT" ]]; then
 fi
 
 echo "NeAntik $VERSION — единый Direct release"
-echo "App Store не используется."
+echo "Канал выпуска: Direct Distribution."
 echo
 
 if [[ -f "$ZIP_PATH" ]]; then

--- a/Sources/NeAntik/ContentView.swift
+++ b/Sources/NeAntik/ContentView.swift
@@ -821,6 +821,7 @@ struct ContentView: View {
         }
         resolvedRuntime = value
         isResolvingRuntime = false
+        presentReleaseFingerprintAuditIfNeeded()
     }
 
     private func presentReleaseFingerprintAuditIfNeeded() {
@@ -841,6 +842,7 @@ struct ContentView: View {
             return
         }
 
+        NSApplication.shared.activate(ignoringOtherApps: true)
         if releaseAuditProfiles.count < 2 {
             releaseAuditProfiles = Self.makeReleaseAuditProfiles()
         }

--- a/Sources/NeAntik/FingerprintAuditView.swift
+++ b/Sources/NeAntik/FingerprintAuditView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Foundation
 import SwiftUI
 
 struct FingerprintAuditView: View {
@@ -136,6 +137,25 @@ struct FingerprintAuditView: View {
                 return
             }
             releaseAuditTerminationScheduled = true
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 350_000_000)
+                NSApplication.shared.terminate(nil)
+            }
+        }
+        .onChange(of: coordinator.errorMessage) { _, message in
+            guard isReleaseAudit,
+                  let message,
+                  !releaseAuditTerminationScheduled
+            else {
+                return
+            }
+            releaseAuditTerminationScheduled = true
+            if let data = (
+                "Автоматическая проверка отпечатка остановлена: " +
+                    "\(message)\n"
+            ).data(using: .utf8) {
+                try? FileHandle.standardError.write(contentsOf: data)
+            }
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 350_000_000)
                 NSApplication.shared.terminate(nil)

--- a/scripts/tests/test_release_launcher.py
+++ b/scripts/tests/test_release_launcher.py
@@ -12,7 +12,7 @@ class ReleaseLauncherTests(unittest.TestCase):
         self.assertIn("verify-direct-notarized-archive.py", text)
         self.assertIn("release-direct-dmg.sh", text)
         self.assertIn("verify-direct-notarized-dmg.sh", text)
-        self.assertIn("App Store не используется.", text)
+        self.assertIn("Канал выпуска: Direct Distribution.", text)
         self.assertIn("ZIP уже существует", text)
         self.assertIn("DMG уже существует", text)
         self.assertNotIn("app-store", text.lower())


### PR DESCRIPTION
## Что исправлено

- релизное окно A → B → A активируется автоматически после готовности встроенного runtime;
- проверка повторно запускает presentation после завершения поиска runtime;
- внутренняя ошибка релизной проверки выводится в защищённый локальный лог и завершает процесс вместо 240-секундного зависания;
- однокнопочный launcher показывает только канал Direct Distribution.

## Проверено

- 253 Swift-теста в 21 suite;
- 31 targeted release-тест;
- zsh syntax и git diff check.

Это узкое исправление блокера выпуска 0.3.14 (17).