### PR TITLE
Fix single-file privacy release gate

### DIFF
--- a/scripts/tests/test_notarize_direct_transaction.py
+++ b/scripts/tests/test_notarize_direct_transaction.py
@@ -303,6 +303,29 @@ class DirectNotaryTransactionTests(unittest.TestCase):
             for command in runner.commands
             if command[:3] == ["xcrun", "stapler", "staple"]
         )
+        privacy_check = next(
+            command
+            for command in runner.commands
+            if any(
+                argument.endswith(
+                    "verify-public-artifact-privacy.py"
+                )
+                for argument in command
+            )
+        )
+        privacy_script_index = next(
+            index
+            for index, argument in enumerate(privacy_check)
+            if argument.endswith(
+                "verify-public-artifact-privacy.py"
+            )
+        )
+        self.assertEqual(
+            privacy_check[privacy_script_index + 1],
+            privacy_check[
+                privacy_check.index("--attestation") + 1
+            ],
+        )
         self.assertIn("/accepted/NeAntik.app", staple[3])
         self.assertEqual(receipt["appleSubmission"]["status"], "Accepted")
         self.assertEqual(receipt["appleSubmission"]["id"], SUBMISSION_ID)

--- a/scripts/tests/test_verify_public_artifact_privacy.py
+++ b/scripts/tests/test_verify_public_artifact_privacy.py
@@ -35,6 +35,52 @@ VERIFIER_SPEC.loader.exec_module(VERIFIER_FIXTURES)
 
 
 class PublicArtifactPrivacyVerifierTests(unittest.TestCase):
+    def test_single_public_file_is_verified_without_parent_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            public = root / "fingerprint-audit-summary.json"
+            private = root / "fingerprint-audit.json"
+            public.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "publicAlphaQualified": True,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            private.write_text(
+                json.dumps(
+                    {
+                        "profileName": "must-not-be-scanned",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = MODULE.verify_public_artifact_privacy(
+                artifact=public
+            )
+
+            self.assertEqual(result.scanned_entries, 1)
+            self.assertEqual(result.artifact, public.resolve())
+
+    def test_single_public_file_rejects_private_values(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            artifact = Path(temporary) / "release.json"
+            artifact.write_text(
+                json.dumps({"proxyPassword": "actual-secret"}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                MODULE.PublicArtifactPrivacyError,
+                "private evidence",
+            ):
+                MODULE.verify_public_artifact_privacy(
+                    artifact=artifact
+                )
+
     def test_clean_directory_passes_without_scanning_sibling_private_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/scripts/verify-public-artifact-privacy.py
+++ b/scripts/verify-public-artifact-privacy.py
@@ -484,6 +484,36 @@ def iter_zip_entries(archive_path: Path) -> Iterator[ArtifactEntry]:
                 )
 
 
+def iter_regular_file_entry(path: Path) -> Iterator[ArtifactEntry]:
+    name = path.name
+    if is_text_entry(name):
+        if path.stat().st_size > MAX_TEXT_FILE_BYTES:
+            raise PublicArtifactPrivacyError(
+                "Text entry is too large for deterministic privacy verification: "
+                + name
+            )
+        with path.open("rb") as file:
+            payload = read_bounded_payload(
+                file,
+                limit=MAX_TEXT_FILE_BYTES,
+                name=name,
+                kind="Text",
+            )
+        yield ArtifactEntry(name=name, payload=payload)
+        return
+    size = path.stat().st_size
+    validate_binary_size(name, size)
+    with path.open("rb") as file:
+        payload = read_bounded_payload(
+            file,
+            limit=MAX_BINARY_FILE_BYTES,
+            name=name,
+            kind="Binary",
+        )
+    validate_safe_binary(name, payload)
+    yield ArtifactEntry(name=name, payload=payload, is_binary=True)
+
+
 def iter_artifact_entries(artifact: Path) -> Iterator[ArtifactEntry]:
     if artifact.is_dir():
         yield from iter_directory_entries(artifact)
@@ -491,8 +521,11 @@ def iter_artifact_entries(artifact: Path) -> Iterator[ArtifactEntry]:
     if artifact.is_file() and zipfile.is_zipfile(artifact):
         yield from iter_zip_entries(artifact)
         return
+    if artifact.is_file():
+        yield from iter_regular_file_entry(artifact)
+        return
     raise PublicArtifactPrivacyError(
-        f"Expected a public artifact directory or ZIP archive: {artifact}"
+        f"Expected a public artifact file, directory or ZIP archive: {artifact}"
     )
 
 
@@ -1161,6 +1194,10 @@ def verify_evidence_attestation_binding(
 
 
 def verify_public_artifact_privacy(*, artifact: Path) -> VerificationResult:
+    if artifact.is_symlink():
+        raise PublicArtifactPrivacyError(
+            "Public artifact cannot be a symlink."
+        )
     artifact = artifact.resolve()
     findings: list[Finding] = []
     scanned_entries = 0
@@ -1202,8 +1239,8 @@ def verify_public_artifact_privacy(*, artifact: Path) -> VerificationResult:
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Verify an explicitly selected public directory or ZIP without scanning "
-            "local private evidence."
+            "Verify an explicitly selected public file, directory or ZIP without "
+            "scanning local private evidence."
         )
     )
     parser.add_argument("artifact", type=Path)


### PR DESCRIPTION
## Что исправлено

- privacy-gate принимает один публичный JSON-файл и не сканирует соседний приватный fingerprint evidence;
- локальная notarization и hosted verification используют один и тот же безопасный контракт;
- добавлены регрессионные тесты для одиночного файла и команды notarization.

## Проверка

- 65 целевых Python-тестов: PASS;
- точная schema-8 attestation/privacy binding для кандидата 0.3.14: PASS.