### PR TITLE
Add restricted AffPapa release channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# NeAntik agent instructions
+
+- NeAntik uses Direct Distribution only. Never use App Store Connect or the
+  Mac App Store.
+- Public release truth is GitHub `AffPapa/neantik` plus
+  `https://affpapa.org/neantik`.
+- Before release or site work run:
+
+  ```bash
+  ./scripts/neantik-affpapa-release doctor
+  ```
+
+- Do not use raw SSH, SCP, SFTP, rsync, or edit the live server directly.
+  Both Codex and Claude must use the same least-privilege client:
+
+  ```bash
+  ./scripts/neantik-affpapa-release publish /absolute/path/to/release-dir
+  ```
+
+- A release directory must contain exactly the six files documented in
+  `ops/affpapa/README.md`.
+- `publish` validates locally, verifies notarized Apple artifacts, uploads only
+  allowlisted files, validates staging, deploys atomically, and verifies live.
+- The deploy key and pinned host key remain outside Git under
+  `../.secrets/ssh/` relative to this checkout. Never print or copy the private
+  key.
+- The restricted server identity must not gain shell, PTY, SFTP/SCP, port
+  forwarding, or permission to upload executable PHP/Blade files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# NeAntik release access
+
+Read and follow `AGENTS.md`.
+
+One access check:
+
+```bash
+./scripts/neantik-affpapa-release doctor
+```
+
+One public release command:
+
+```bash
+./scripts/neantik-affpapa-release publish /absolute/path/to/release-dir
+```
+
+Never use raw SSH/SCP/SFTP for this project and never request or display
+private keys, Apple passwords, or notarization secrets.

--- a/README.md
+++ b/README.md
@@ -190,3 +190,21 @@ fingerprint seed или proxy-конфигурации.
 Исходники NeAntik распространяются по MPL-2.0. Производные файлы Chromium
 сохраняют свои upstream-лицензии и notices. Название и логотип регулируются
 [TRADEMARKS.md](TRADEMARKS.md).
+
+## Выпуск на AffPapa
+
+Codex и Claude используют один ограниченный release-клиент. Проверить доступ,
+текущий релиз и публичные файлы одной командой:
+
+```bash
+./scripts/neantik-affpapa-release doctor
+```
+
+Опубликовать уже подготовленный release-каталог:
+
+```bash
+./scripts/neantik-affpapa-release publish /absolute/path/to/release-dir
+```
+
+Ручные SSH/SCP/SFTP для этого не нужны и запрещены серверным forced-command.
+Полный контракт: [ops/affpapa/README.md](ops/affpapa/README.md).

--- a/ops/affpapa/README.md
+++ b/ops/affpapa/README.md
@@ -1,0 +1,80 @@
+# NeAntik AffPapa release channel
+
+This directory is the source of truth for the least-privilege hosted release
+channel at `https://affpapa.org/neantik`.
+
+## Operator command
+
+Both local Claude and Codex use the same wrapper:
+
+```bash
+cd /path/to/neantik-open-source
+./scripts/neantik-affpapa-release doctor
+```
+
+`doctor` is the single access check: it verifies the local key permissions and
+both pinned fingerprints, connects through the restricted SSH identity,
+confirms that arbitrary commands remain denied, and checks the live landing,
+JSON manifests, DMG and ZIP.
+
+The wrapper pins:
+
+- deploy key fingerprint
+  `SHA256:VM+qNg4wh4bdPfBMN+0vUyeXvazmPdrlT84SfAhLs18`;
+- server host-key fingerprint
+  `SHA256:Q/dEY6G+KRaAk1sDgOAaaVxLZxIrQZElszGwVyn5OU8`;
+- `BatchMode`, `IdentitiesOnly`, strict host-key checking, and no connection
+  multiplexing.
+
+Private keys are kept outside the repository in `../.secrets/ssh/` and are
+never stored in Git, release artifacts, logs, or chat.
+
+## Release directory contract
+
+A candidate directory contains exactly:
+
+```text
+release.json
+content.json
+NeAntik-<version>-arm64-notarized.dmg
+NeAntik-<version>-arm64-notarized.dmg.sha256
+NeAntik-<version>-arm64-notarized.zip
+NeAntik-<version>-arm64-notarized.zip.sha256
+```
+
+`release.json` is the public machine-readable release contract.
+`content.json` contains the public changelog. The root-owned Blade template
+reads both files, so a normal release updates version, links, SHA values, and
+changelog without uploading executable PHP.
+
+## Normal release
+
+Check and stage without publishing:
+
+```bash
+./scripts/neantik-affpapa-release prepare /absolute/path/to/release-dir
+```
+
+Publish in one explicit transaction:
+
+```bash
+./scripts/neantik-affpapa-release publish /absolute/path/to/release-dir
+```
+
+The publish command performs local validation, clears only stale NeAntik
+staging, uploads six allowlisted files, runs the server check, publishes
+artifacts first and `release.json` last, then checks the live landing,
+manifests, and Range sizes.
+
+## Safety boundary
+
+The restricted SSH identity cannot open a shell, allocate a PTY, use SFTP/SCP,
+forward ports, upload Blade/PHP, or execute arbitrary commands. It can only:
+
+- show status;
+- upload allowlisted release files;
+- check/dry-run/deploy the NeAntik staging transaction;
+- clear only NeAntik staging;
+- check or execute the latest NeAntik rollback.
+
+The Mac App Store and App Store Connect are outside this pipeline.

--- a/ops/affpapa/bootstrap/content.json
+++ b/ops/affpapa/bootstrap/content.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": 1,
+  "product": "NeAntik",
+  "releaseVersion": "0.3.14",
+  "updatedAt": "2026-08-04",
+  "changelog": [
+    {
+      "version": "0.3.14",
+      "build": 17,
+      "date": "4 августа 2026",
+      "label": "Public Alpha",
+      "items": [
+        "Проверка профиля стала одним понятным действием с результатом «пройдена / не пройдена»",
+        "Добавлены локальные иконки, цвета, теги, поиск и фильтрация профилей",
+        "Исправлен запуск удалённых профилей без создания пустых BrowserData-каталогов",
+        "Уменьшена лишняя работа в горячем пути запуска и безопасно очищаются пустые временные каталоги проверки",
+        "Релизная A → B → A проверка автоматизирована и привязана к точной подписанной сборке",
+        "Доступны нотарифицированные DMG и ZIP для Apple Silicon"
+      ]
+    },
+    {
+      "version": "0.3.13",
+      "build": 16,
+      "date": "30 июля 2026",
+      "label": "Public Alpha",
+      "items": [
+        "Chromium 150.0.7871.186 ARM64/Metal — обновлён public alpha release",
+        "GUI fingerprint A → B → A проходит public-alpha gate",
+        "Direct telemetry выключена",
+        "Скачка ZIP напрямую с affpapa.org",
+        "release.json для внешних интеграций"
+      ]
+    },
+    {
+      "version": "0.3.12",
+      "build": 15,
+      "date": "28 июля 2026",
+      "items": [
+        "Встроен проверенный Chromium 150.0.7871.186 ARM64 с Metal",
+        "Совместимость окон: минимум 760 × 520",
+        "Улучшена миграция профилей и обработка Keychain",
+        "Исправлены индикаторы состояния профиля",
+        "Русская локализация",
+        "Реализована проверка A → B → A",
+        "Developer ID, Apple notarization и Gatekeeper verified"
+      ]
+    },
+    {
+      "version": "0.3.1",
+      "build": 4,
+      "date": "25 июля 2026",
+      "items": [
+        "Защита от PID reuse не остановит чужой Chrome",
+        "Owner-only 0600/0700 для metadata, отчётов и lock-файлов",
+        "Rollback при ошибке записи на диск",
+        "Строгая валидация DNS, IPv4 и IPv6 proxy hosts",
+        "Отключение QUIC в proxy-режиме",
+        "Одноразовые browser-data directories для fingerprint check",
+        "Proxy-пароли не попадают в process arguments",
+        "Пройдены автоматические тесты Direct-сборки"
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "build": 3,
+      "date": "24 июля 2026",
+      "items": [
+        "Встроенный fingerprint check A → B → A",
+        "Canvas, WebGL, Audio, ClientRects, GPU, Client Hints, fonts и WebRTC",
+        "Verdicts: verified, partial, unchanged, unstable",
+        "Runtime manifest: Standard, Fingerprint и Cloak flavors",
+        "Preflight: path, executable, Mach-O, signature и version",
+        "Проверяемая Direct Distribution сборка для macOS"
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "build": 2,
+      "date": "24 июля 2026",
+      "items": [
+        "Постоянный fingerprint seed для каждого профиля",
+        "Различение stock Chrome и fingerprint-compatible runtime",
+        "Проверка proxy: exit IP, город, страна, timezone и locale",
+        "DNS и WebRTC leak controls",
+        "Проверка ARM64: Intel-only runtime не предлагается"
+      ]
+    },
+    {
+      "version": "0.1",
+      "build": 1,
+      "date": "24 июля 2026",
+      "label": "Prototype",
+      "items": [
+        "Первый SwiftUI MVP для Apple Silicon",
+        "Создание, редактирование и удаление профилей",
+        "Отдельный Chromium data directory на профиль",
+        "Постоянные cookies, local storage и sessions",
+        "HTTP/HTTPS и SOCKS5 proxy, пароли в Keychain",
+        "Process locks и browser logs"
+      ]
+    }
+  ]
+}

--- a/ops/affpapa/bootstrap/neantik.blade.php
+++ b/ops/affpapa/bootstrap/neantik.blade.php
@@ -1,0 +1,748 @@
+@extends('affpapa.layout')
+
+@section('title', 'NeAntik — антидетект-браузер для Apple Silicon Mac | AffPapa')
+@section('description', 'NeAntik — нативный менеджер браузерных профилей для macOS со встроенным Chromium. Изолированные сессии, прокси, локальное хранение и проверка fingerprint A→B→A. SwiftUI, без Electron, без облака.')
+@section('canonical', 'https://affpapa.org/neantik')
+
+@php
+    $releaseManifestPath = public_path('neantik/release.json');
+    $contentManifestPath = public_path('neantik/content.json');
+    $releaseManifest = is_file($releaseManifestPath)
+        ? json_decode((string) file_get_contents($releaseManifestPath), true)
+        : [];
+    $contentManifest = is_file($contentManifestPath)
+        ? json_decode((string) file_get_contents($contentManifestPath), true)
+        : [];
+    $releaseManifest = is_array($releaseManifest) ? $releaseManifest : [];
+    $contentManifest = is_array($contentManifest) ? $contentManifest : [];
+    $releaseVersion = (string) ($releaseManifest['version'] ?? '0.3.14');
+    $releaseBuild = (int) ($releaseManifest['build'] ?? 17);
+    $runtimeVersion = (string) ($releaseManifest['runtime']['version'] ?? '150.0.7871.186');
+    $runtimeMajor = explode('.', $runtimeVersion)[0] ?? '150';
+    $artifactByFormat = [];
+    foreach (($releaseManifest['artifacts'] ?? []) as $artifact) {
+        if (is_array($artifact) && isset($artifact['format'])) {
+            $artifactByFormat[$artifact['format']] = $artifact;
+        }
+    }
+
+    $faqs = [
+        ['q' => 'Это антидетект-браузер?', 'a' => 'NeAntik — нативный менеджер изолированных Chromium-профилей с fingerprint-протоколом. Он разделяет cookies, storage и proxy между профилями и включает встроенный Chromium '.$runtimeMajor.' с поддержкой Metal. Canvas, WebGL, Audio и device signals проверяются встроенной процедурой A→B→A.'],
+        ['q' => 'Нужен ли установленный Chrome?', 'a' => 'Нет. NeAntik включает собственный Chromium '.$runtimeVersion.' ARM64 с Metal. Внешний браузер не требуется — всё работает из коробки.'],
+        ['q' => 'Чем профиль NeAntik отличается от инкогнито?', 'a' => 'Инкогнито временно отделяет cookies и историю, но не создаёт постоянную сессию и не меняет fingerprint устройства. Профиль NeAntik сохраняется между запусками, использует отдельный data directory и может иметь собственный proxy и identity.'],
+        ['q' => 'Где хранятся профили?', 'a' => 'Локально на Mac — в Application Support. Proxy-пароли хранятся отдельно в macOS Keychain. Облака и серверов нет.'],
+        ['q' => 'Нужен ли аккаунт?', 'a' => 'Нет. Нет аккаунта, облачной синхронизации, аналитики или телеметрии.'],
+        ['q' => 'Поддерживается ли Intel Mac?', 'a' => 'Нет. NeAntik создан только для Apple Silicon (M1–M4) и выпускается как ARM64-only.'],
+        ['q' => 'Поддерживаются ли прокси?', 'a' => 'Да. NeAntik поддерживает Direct, HTTP и HTTPS с логином и паролем, а также SOCKS5 без авторизации. Пароли HTTP/HTTPS хранятся в macOS Keychain.'],
+        ['q' => 'Гарантирует ли NeAntik анонимность?', 'a' => 'Нет. Ни один браузер не может честно это гарантировать. Proxy, аккаунты, поведение и расширения могут связывать сессии. NeAntik уменьшает пересечение профилей и даёт инструмент для измерения fingerprint, но не обещает невозможность корреляции.'],
+        ['q' => 'Что показывает Fingerprint Check?', 'a' => 'Он сравнивает два профиля (A → B → A) и проверяет: отличаются ли fingerprint-поверхности между профилями и стабилен ли результат при повторном запуске. Verdict: verified, partial, unchanged или unstable.'],
+        ['q' => 'Как обновляется встроенный Chromium?', 'a' => 'Новая версия Chromium поставляется вместе с обновлением NeAntik. Текущая версия — '.$runtimeVersion.' ARM64 с Metal.'],
+        ['q' => 'Это правила сайтов или капчи?', 'a' => 'NeAntik не обходит правила сайтов и не решает капчи. Каждый профиль — это отдельный рабочий контекст, как отдельный браузер. Ответственность за соблюдение правил площадок — на пользователе.'],
+    ];
+
+    $changelog = [
+        [
+            'ver' => '0.3.14',
+            'build' => 17,
+            'date' => '4 августа 2026',
+            'label' => 'Public Alpha',
+            'items' => [
+                'Проверка профиля стала одним понятным действием с результатом «пройдена / не пройдена»',
+                'Добавлены локальные иконки, цвета, теги, поиск и фильтрация профилей',
+                'Исправлен запуск удалённых профилей без создания пустых BrowserData-каталогов',
+                'Уменьшена лишняя работа в горячем пути запуска и безопасно очищаются пустые временные каталоги проверки',
+                'Релизная A → B → A проверка автоматизирована и привязана к точной подписанной сборке',
+                'Доступны нотарифицированные DMG и ZIP для Apple Silicon',
+            ],
+        ],
+        [
+            'ver' => '0.3.13',
+            'build' => 16,
+            'date' => '30 июля 2026',
+            'label' => 'Public Alpha',
+            'items' => [
+                'Chromium 150.0.7871.186 ARM64/Metal — обновлён public alpha release',
+                'GUI fingerprint A → B → A проходит public-alpha gate',
+                'Direct telemetry выключена',
+                'Скачка ZIP напрямую с affpapa.org',
+                'release.json для внешних интеграций',
+            ],
+        ],
+        [
+            'ver' => '0.3.12',
+            'build' => 15,
+            'date' => '28 июля 2026',
+            'items' => [
+                'Встроен проверенный Chromium 150.0.7871.186 ARM64 с Metal',
+                'Совместимость окон (минимум 760 × 520)',
+                'Улучшена миграция профилей и обработка Keychain',
+                'Исправлены индикаторы состояния профиля',
+                'Русская локализация',
+                'Реализована проверка A→B→A',
+                'Developer ID + Apple notarization + Gatekeeper verified',
+            ],
+        ],
+        [
+            'ver' => '0.3.1',
+            'build' => 4,
+            'date' => '25 июля 2026',
+            'items' => [
+                'Защита от PID reuse — не остановит чужой Chrome',
+                'Owner-only (0600/0700) для metadata, отчётов и lock-файлов',
+                'Rollback при ошибке записи на диск',
+                'Строгая валидация DNS, IPv4, IPv6 proxy hosts',
+                'Отключение QUIC в proxy-режиме',
+                'Одноразовые browser-data directories для fingerprint check',
+                'Proxy-пароли не попадают в process arguments',
+                'Пройдены автоматические тесты Direct-сборки',
+            ],
+        ],
+        [
+            'ver' => '0.3.0',
+            'build' => 3,
+            'date' => '24 июля 2026',
+            'items' => [
+                'Встроенный fingerprint check A → B → A',
+                'Canvas, WebGL, Audio, ClientRects, GPU, Client Hints, fonts, WebRTC',
+                'Verdicts: verified, partial, unchanged, unstable',
+                'Runtime manifest: Standard, Fingerprint, Cloak flavors',
+                'Preflight: path, executable, Mach-O, signature, version',
+                'Проверяемая Direct Distribution сборка для macOS',
+            ],
+        ],
+        [
+            'ver' => '0.2.0',
+            'build' => 2,
+            'date' => '24 июля 2026',
+            'items' => [
+                'Постоянный fingerprint seed для каждого профиля',
+                'Различение stock Chrome и fingerprint-compatible runtime',
+                'Проверка proxy: exit IP, город, страна, timezone, locale',
+                'DNS и WebRTC leak controls',
+                'Проверка ARM64 — Intel-only runtime не предлагается',
+            ],
+        ],
+        [
+            'ver' => '0.1',
+            'build' => 1,
+            'date' => '24 июля 2026',
+            'label' => 'Prototype',
+            'items' => [
+                'Первый SwiftUI MVP для Apple Silicon',
+                'Создание, редактирование, удаление профилей',
+                'Отдельный Chromium data directory на профиль',
+                'Постоянные cookies, local storage, sessions',
+                'HTTP/HTTPS и SOCKS5 proxy, пароли в Keychain',
+                'Process locks и browser logs',
+            ],
+        ],
+    ];
+    if (!empty($contentManifest['changelog']) && is_array($contentManifest['changelog'])) {
+        $changelog = array_map(static fn (array $release): array => [
+            'ver' => (string) ($release['version'] ?? ''),
+            'build' => (int) ($release['build'] ?? 0),
+            'date' => (string) ($release['date'] ?? ''),
+            'label' => isset($release['label']) ? (string) $release['label'] : null,
+            'items' => array_values(array_filter(
+                $release['items'] ?? [],
+                static fn ($item): bool => is_string($item)
+            )),
+        ], $contentManifest['changelog']);
+    }
+
+    $compareHeaders = ['', 'NeAntik', 'Multilogin', 'GoLogin', 'AdsPower', 'Dolphin Anty', 'Octo'];
+    $compare = [
+        ['Тип',             'Native macOS',  'Кросс-платформа', 'Кросс-платформа', 'Кросс-платформа', 'Кросс-платформа', 'Кросс-платформа'],
+        ['Движок',          'SwiftUI + Chromium', 'Electron/Web', 'Electron',      'Electron',        'Electron',        'Electron/Web'],
+        ['Браузер внутри',  'Chromium '.$runtimeMajor.' ARM64', 'Mimic/Stealthfox', 'Orbita',    'SunBrowser',      'Anty Browser',    'Octo Browser'],
+        ['Облако',          'Нет',           'Да',              'Да',              'Да',              'Да (старшие)',    'Да'],
+        ['Аккаунт',         'Не нужен',      'Нужен',           'Нужен',           'Нужен',           'Нужен',           'Нужен'],
+        ['Команды и роли',  '—',             '✓',               '✓',               '✓',               '✓',               '✓'],
+        ['Fingerprint',     'Seed + A→B→A проверка', 'Генерация', 'Генерация',   'Генерация',       'Генерация',       'Генерация'],
+        ['Проверка результата', '✓ встроенная', '—',            '—',               '—',               '—',               '—'],
+        ['Телеметрия',      'Нет',           'Есть',            'Есть',            'Есть',            'Есть',            'Есть'],
+        ['Для кого',        'Индивид. на Mac', 'Команды',       'Команды',         'Команды',         'Affiliate-команды','Команды'],
+    ];
+
+    $surfaces = ['Canvas', 'WebGL pixels', 'WebGL vendor/renderer', 'Audio', 'ClientRects', 'GPU/device', 'Client Hints', 'Fonts', 'Timezone/locale', 'WebRTC'];
+
+    $proofItems = [
+        ['num' => $releaseVersion, 'label' => 'текущая версия'],
+        ['num' => $runtimeMajor, 'label' => 'Chromium ARM64'],
+        ['num' => '10', 'label' => 'поверхностей A→B→A'],
+        ['num' => (string) $releaseBuild, 'label' => 'текущий build'],
+    ];
+
+    $dmgDownloadUrl = (string) ($artifactByFormat['dmg']['url'] ?? '#');
+    $zipDownloadUrl = (string) ($artifactByFormat['zip']['url'] ?? '#');
+    $githubReleaseUrl = (string) ($releaseManifest['source']['release'] ?? 'https://github.com/AffPapa/neantik/releases');
+    $dmgSha256 = (string) ($artifactByFormat['dmg']['sha256'] ?? '');
+    $zipSha256 = (string) ($artifactByFormat['zip']['sha256'] ?? '');
+@endphp
+
+@push('head')
+<meta property="og:type" content="product">
+<script type="application/ld+json">{!! json_encode([
+    chr(64).'context' => 'https://schema.org',
+    '@graph' => [
+        [
+            '@type' => 'SoftwareApplication',
+            '@id' => 'https://affpapa.org/neantik#app',
+            'name' => 'NeAntik',
+            'applicationCategory' => 'UtilityApplication',
+            'operatingSystem' => 'macOS 14 or later',
+            'softwareVersion' => $releaseVersion,
+            'processorRequirements' => 'Apple Silicon / ARM64',
+            'downloadUrl' => $dmgDownloadUrl,
+            'description' => 'Нативный менеджер изолированных браузерных профилей для Apple Silicon Mac со встроенным Chromium и проверкой fingerprint A→B→A.',
+        ],
+        [
+            '@type' => 'FAQPage',
+            '@id' => 'https://affpapa.org/neantik#faq',
+            'mainEntity' => array_map(fn ($f) => [
+                '@type' => 'Question',
+                'name' => $f['q'],
+                'acceptedAnswer' => ['@type' => 'Answer', 'text' => $f['a']],
+            ], $faqs),
+        ],
+    ],
+], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!}</script>
+<style>
+/* ── Scroll reveal ── */
+.nk-reveal { opacity:0; transform:translateY(12px); transition:opacity 400ms cubic-bezier(.23,1,.32,1), transform 400ms cubic-bezier(.23,1,.32,1); }
+.nk-reveal.is-visible { opacity:1; transform:translateY(0); }
+@media (prefers-reduced-motion:reduce) { .nk-reveal { opacity:1; transform:none; transition:none; } }
+
+/* ── Hero two-col ── */
+.nk-hero-grid { display:grid; grid-template-columns:1fr; gap:2rem; align-items:center; }
+@media (min-width:740px) { .nk-hero-grid { grid-template-columns:1fr 280px; } }
+.nk-hero-visual { display:flex; align-items:center; justify-content:center; }
+.nk-hero-icon { width:180px; height:180px; border-radius:32px; background:var(--accent-soft); border:1px solid var(--line); display:flex; align-items:center; justify-content:center; overflow:hidden; }
+.nk-hero-icon svg { width:100px; height:100px; }
+@media (max-width:739px) { .nk-hero-visual { display:none; } }
+
+/* ── Platform line ── */
+.nk-platform { display:flex; flex-wrap:wrap; gap:.5rem; margin-top:1rem; }
+.nk-platform .chip { font-family:var(--mono); font-size:.72rem; letter-spacing:.02em; }
+
+/* ── A→B→A interactive ── */
+.nk-aba-demo { margin:1.5rem 0; }
+.nk-aba { display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; margin:0 0 .75rem; }
+.nk-aba__node { position:relative; display:flex; flex-direction:column; align-items:center; gap:.2rem; padding:.7rem 1.1rem; border:1px solid var(--line); border-radius:var(--radius-sm); background:var(--bg-soft); min-width:90px; transition:border-color 250ms var(--ease-out), background 250ms var(--ease-out); }
+.nk-aba__node--active { border-color:var(--accent-dim); background:var(--accent-soft); }
+.nk-aba__node--done { border-color:var(--money, var(--accent-dim)); }
+.nk-aba__node-label { font-family:var(--mono); font-size:.85rem; font-weight:700; color:var(--ink); }
+.nk-aba__node-sub { font-size:.72rem; color:var(--ink-2); transition:color 200ms var(--ease-out); }
+.nk-aba__node--active .nk-aba__node-sub { color:var(--accent-dim); }
+.nk-aba__arrow { color:var(--ink-2); font-size:1.1rem; opacity:.4; transition:opacity 200ms var(--ease-out); }
+.nk-aba__arrow--active { opacity:1; color:var(--accent-dim); }
+.nk-aba__verdict { font-family:var(--mono); font-size:.82rem; font-weight:700; padding:.3rem .7rem; border-radius:var(--radius-sm); opacity:0; transform:scale(.95); transition:opacity 250ms var(--ease-out), transform 250ms var(--ease-out); }
+.nk-aba__verdict.is-visible { opacity:1; transform:scale(1); }
+.nk-aba__verdict--verified { color:var(--money); background:rgba(91,228,155,.08); border:1px solid rgba(91,228,155,.2); }
+.nk-aba__btn { font-family:var(--mono); font-size:.78rem; padding:.45rem .9rem; border-radius:var(--radius-sm); border:1px solid var(--line); background:var(--bg-soft); color:var(--ink-2); cursor:pointer; transition:border-color 150ms var(--ease-out), color 150ms var(--ease-out), transform 120ms var(--ease-out); }
+.nk-aba__btn:active { transform:scale(.97); }
+@media (hover:hover) and (pointer:fine) { .nk-aba__btn:hover { border-color:var(--accent-dim); color:var(--accent-dim); } }
+
+/* ── Surfaces chips ── */
+.nk-surfaces { display:flex; flex-wrap:wrap; gap:.35rem; margin-top:.75rem; }
+.nk-surfaces .chip { font-size:.75rem; }
+
+/* ── Problem section ── */
+.nk-problem { max-width:38rem; }
+.nk-problem p { color:var(--ink-2); font-size:.95rem; line-height:1.55; margin-bottom:.75rem; }
+.nk-problem p:last-child { margin-bottom:0; }
+
+/* ── Local-first cards ── */
+.nk-local-cards { display:grid; grid-template-columns:1fr; gap:.75rem; }
+@media (min-width:600px) { .nk-local-cards { grid-template-columns:repeat(3,1fr); } }
+.nk-local-card { padding:1.15rem; }
+.nk-local-card h3 { margin:0 0 .3rem; font-size:.95rem; font-weight:700; }
+.nk-local-card p { margin:0; color:var(--ink-2); font-size:.88rem; line-height:1.45; }
+.nk-local-card__icon { font-family:var(--mono); font-size:.75rem; font-weight:600; color:var(--accent-dim); margin-bottom:.5rem; display:block; }
+
+/* ── Feature cards ── */
+.nk-features { display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:1rem; }
+.nk-feat { position:relative; padding:1.25rem; }
+.nk-feat__icon { width:2.2rem; height:2.2rem; display:flex; align-items:center; justify-content:center; border-radius:var(--radius-sm); background:var(--accent-soft); color:var(--accent-dim); font-family:var(--mono); font-size:1.1rem; font-weight:700; margin-bottom:.75rem; }
+.nk-feat h3 { margin:0 0 .35rem; font-size:1rem; font-weight:700; }
+.nk-feat p { margin:0; color:var(--ink-2); font-size:.92rem; line-height:1.45; }
+
+/* ── Steps ── */
+.nk-steps { counter-reset:step; display:grid; gap:.6rem; }
+.nk-step { position:relative; padding:.9rem 1rem .9rem 3.4rem; }
+.nk-step::before { counter-increment:step; content:counter(step); position:absolute; left:1rem; top:.9rem; width:1.8rem; height:1.8rem; display:flex; align-items:center; justify-content:center; border-radius:50%; background:var(--accent-soft); color:var(--accent-dim); font-family:var(--mono); font-weight:700; font-size:.85rem; }
+.nk-step h3 { margin:0 0 .2rem; font-size:.95rem; font-weight:700; }
+.nk-step p { margin:0; color:var(--ink-2); font-size:.88rem; }
+
+/* ── Proof stats ── */
+.nk-proof { display:grid; grid-template-columns:repeat(auto-fit,minmax(120px,1fr)); gap:.75rem; margin-top:1rem; }
+.nk-proof-stat { padding:.85rem; text-align:center; }
+.nk-proof-stat__num { display:block; font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:1.6rem; font-weight:800; color:var(--ink); letter-spacing:-0.03em; }
+.nk-proof-stat__label { display:block; font-size:.78rem; color:var(--ink-2); margin-top:.15rem; }
+
+/* ── Comparison table ── */
+.nk-compare-wrap { overflow-x:auto; border:1px solid var(--line); border-radius:var(--radius); }
+.nk-compare { width:100%; border-collapse:collapse; font-size:.82rem; min-width:780px; }
+.nk-compare th, .nk-compare td { padding:.6rem .7rem; text-align:left; border-bottom:1px solid var(--line); vertical-align:top; }
+.nk-compare thead th { font-weight:700; color:var(--ink); background:var(--bg-soft); position:sticky; top:0; z-index:2; }
+.nk-compare thead th:nth-child(2) { color:var(--accent-dim); }
+.nk-compare tbody th { font-weight:500; color:var(--ink-2); background:var(--bg); position:sticky; left:0; z-index:1; }
+.nk-compare tbody td { color:var(--ink); }
+.nk-compare tbody td:first-of-type { color:var(--accent-dim); font-weight:600; }
+.nk-compare tr:last-child th, .nk-compare tr:last-child td { border-bottom:0; }
+@media (hover:hover) and (pointer:fine) {
+    .nk-compare tbody tr { transition:background-color 120ms ease; }
+    .nk-compare tbody tr:hover { background:var(--bg-soft); }
+}
+
+/* ── Changelog ── */
+.nk-changelog { display:grid; gap:1.5rem; }
+.nk-release { position:relative; padding-left:1.5rem; border-left:2px solid var(--line); }
+.nk-release__head { display:flex; align-items:baseline; gap:.5rem; flex-wrap:wrap; margin-bottom:.4rem; }
+.nk-release__ver { font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:1rem; font-weight:800; color:var(--ink); }
+.nk-release__label { font-size:.75rem; color:var(--accent-dim); font-weight:600; }
+.nk-release__date { font-size:.78rem; color:var(--ink-2); }
+.nk-release__list { margin:0; padding:0 0 0 1rem; }
+.nk-release__list li { font-size:.88rem; color:var(--ink-2); line-height:1.5; margin-bottom:.2rem; }
+.nk-release:first-child { border-left-color:var(--accent-dim); }
+
+/* ── Honest boundary ── */
+.nk-boundary { padding:1.15rem 1.25rem; border-left:3px solid var(--accent); border-radius:0 var(--radius-sm) var(--radius-sm) 0; background:var(--bg-soft); }
+.nk-boundary__title { font-size:.9rem; font-weight:700; color:var(--ink); margin:0 0 .5rem; }
+.nk-boundary p { margin:.4rem 0 0; font-size:.88rem; color:var(--ink-2); line-height:1.55; }
+.nk-boundary p:first-of-type { margin:0; }
+
+/* ── Editions ── */
+.nk-editions { display:grid; grid-template-columns:1fr; gap:1rem; }
+@media (min-width:600px) { .nk-editions { grid-template-columns:1fr 1fr; } }
+.nk-edition { padding:1.25rem; }
+.nk-edition h3 { margin:0 0 .35rem; font-size:1rem; font-weight:700; }
+.nk-edition p { margin:0; color:var(--ink-2); font-size:.88rem; line-height:1.45; }
+.nk-edition__badge { display:inline-block; font-family:var(--mono); font-size:.7rem; font-weight:600; padding:.15rem .45rem; border-radius:999px; margin-bottom:.5rem; }
+.nk-edition__badge--direct { background:var(--accent-soft); color:var(--accent-dim); }
+
+/* ── Security chips ── */
+.nk-security { display:flex; flex-wrap:wrap; gap:.5rem; margin-top:1rem; }
+.nk-security .chip { font-family:var(--mono); font-size:.72rem; letter-spacing:.02em; }
+.nk-security .chip--verified { border-color:rgba(91,228,155,.3); color:var(--money); }
+
+/* ── SHA line ── */
+.nk-sha { font-family:var(--mono); font-size:.72rem; color:var(--ink-2); word-break:break-all; line-height:1.5; margin-top:.75rem; padding:.6rem .8rem; background:var(--bg-soft); border:1px solid var(--line); border-radius:var(--radius-sm); }
+.nk-sha strong { color:var(--ink); font-weight:600; }
+
+/* ── Privacy cards ── */
+.nk-privacy { display:grid; grid-template-columns:1fr; gap:.75rem; }
+@media (min-width:600px) { .nk-privacy { grid-template-columns:1fr 1fr; } }
+.nk-privacy-card { padding:1.15rem; }
+.nk-privacy-card h3 { margin:0 0 .35rem; font-size:.95rem; font-weight:700; }
+.nk-privacy-card ul { margin:.3rem 0 0; padding:0 0 0 1.1rem; }
+.nk-privacy-card li { color:var(--ink-2); font-size:.88rem; line-height:1.5; margin-bottom:.15rem; }
+.nk-privacy-card__icon { font-family:var(--mono); font-size:.75rem; font-weight:600; margin-bottom:.5rem; display:block; }
+.nk-privacy-card__icon--green { color:var(--money); }
+.nk-privacy-card__icon--muted { color:var(--ink-2); }
+
+/* ── FAQ smooth ── */
+.nk-faq-item { border:1px solid var(--line); border-radius:var(--radius-sm); margin-bottom:.6rem; background:var(--bg); overflow:hidden; }
+.nk-faq-item__q { width:100%; border:none; background:none; padding:.85rem 2.5rem .85rem 1rem; font:inherit; font-weight:600; font-size:1rem; color:var(--ink); text-align:left; cursor:pointer; position:relative; }
+.nk-faq-item__q::after { content:'+'; position:absolute; right:1rem; top:.85rem; font-family:var(--mono); color:var(--accent-dim); font-size:1.1rem; transition:transform 200ms var(--ease-out); }
+.nk-faq-item.is-open .nk-faq-item__q::after { transform:rotate(45deg); }
+@media (hover:hover) and (pointer:fine) { .nk-faq-item__q:hover { color:var(--accent-dim); } }
+.nk-faq-item__a { display:grid; grid-template-rows:0fr; transition:grid-template-rows 250ms var(--ease-out); }
+.nk-faq-item.is-open .nk-faq-item__a { grid-template-rows:1fr; }
+.nk-faq-item__a-inner { overflow:hidden; }
+.nk-faq-item__a-inner p { padding:0 1rem .85rem; margin:0; color:var(--ink-2); font-size:.92rem; line-height:1.5; }
+@media (prefers-reduced-motion:reduce) { .nk-faq-item__a { transition:none; } }
+
+/* ── Product screenshots ── */
+.nk-screenshots { display:grid; grid-template-columns:1fr; gap:1.25rem; }
+@media (min-width:740px) { .nk-screenshots { grid-template-columns:repeat(3,1fr); } }
+.nk-screenshot { border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--bg-soft); }
+.nk-screenshot img { width:100%; height:auto; display:block; }
+.nk-screenshot__caption { padding:.75rem 1rem; }
+.nk-screenshot__caption h3 { margin:0 0 .2rem; font-size:.95rem; font-weight:700; }
+.nk-screenshot__caption p { margin:0; color:var(--ink-2); font-size:.82rem; line-height:1.45; }
+
+/* ── Buttons ── */
+.btn:active { transform:scale(.97); }
+.btn--disabled { opacity:.5; pointer-events:none; }
+</style>
+@endpush
+
+@section('content')
+    {{-- ═══ HERO ═══ --}}
+    <section class="hero" id="top">
+        <div class="nk-hero-grid">
+            <div>
+                <p class="badge"><span class="badge-dot" aria-hidden="true"></span>Public Alpha · Apple Silicon · Chromium {{ $runtimeMajor }}</p>
+                <h1 class="hero-title">Отдельный браузер<br>для каждой рабочей сессии</h1>
+                <p class="hero-lead">NeAntik разделяет cookies, сессии, storage и&nbsp;proxy между профилями. Встроенный Chromium {{ $runtimeMajor }} — ничего не&nbsp;нужно устанавливать отдельно. SwiftUI, без Electron, без аккаунта, без телеметрии.</p>
+
+                <div class="nk-platform">
+                    <span class="chip">macOS 14+</span>
+                    <span class="chip">Apple Silicon</span>
+                    <span class="chip">ARM64 only</span>
+                    <span class="chip">SwiftUI</span>
+                    <span class="chip">v{{ $releaseVersion }}</span>
+                    <span class="chip">Chromium {{ $runtimeMajor }}</span>
+                </div>
+
+                <div class="hero-actions" style="margin-top:1.25rem;">
+                    <a class="btn btn-primary" href="{{ $dmgDownloadUrl }}">Скачать DMG</a>
+                    <a class="btn btn-ghost" href="{{ $zipDownloadUrl }}">Скачать ZIP</a>
+                    <a class="btn btn-ghost" href="{{ $githubReleaseUrl }}" rel="noopener">GitHub Release</a>
+                </div>
+
+                <div class="nk-security">
+                    <span class="chip chip--verified">Developer ID</span>
+                    <span class="chip chip--verified">Apple Notarized</span>
+                    <span class="chip chip--verified">Gatekeeper Verified</span>
+                </div>
+            </div>
+            <div class="nk-hero-visual">
+                <div class="nk-hero-icon" aria-hidden="true">
+                    <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <rect x="18" y="22" width="64" height="48" rx="6" stroke="var(--accent-dim)" stroke-width="2.5" fill="none"/>
+                        <rect x="28" y="32" width="18" height="28" rx="3" stroke="var(--ink-2)" stroke-width="1.5" fill="var(--accent-soft)" opacity=".6"/>
+                        <rect x="54" y="32" width="18" height="28" rx="3" stroke="var(--ink-2)" stroke-width="1.5" fill="var(--bg-soft)" opacity=".6"/>
+                        <line x1="50" y1="36" x2="50" y2="56" stroke="var(--accent-dim)" stroke-width="1" stroke-dasharray="3 2"/>
+                        <path d="M40 76 50 82 60 76" stroke="var(--accent-dim)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    {{-- ═══ SCREENSHOTS ═══ --}}
+    <section class="section nk-reveal" id="neantik-screenshots">
+        <div class="section-head"><h2>Как выглядит NeAntik</h2></div>
+        <div class="nk-screenshots">
+            <div class="nk-screenshot nk-reveal" style="transition-delay:0ms">
+                <img src="/img/neantik/profiles.svg" alt="NeAntik — менеджер профилей" width="1440" height="900" loading="lazy">
+                <div class="nk-screenshot__caption">
+                    <h3>Профили и запуск</h3>
+                    <p>Локальные профили, понятный статус proxy и быстрый запуск браузера без тяжёлой shell-платформы.</p>
+                </div>
+            </div>
+            <div class="nk-screenshot nk-reveal" style="transition-delay:80ms">
+                <img src="/img/neantik/audit.svg" alt="NeAntik — fingerprint audit A→B→A" width="1440" height="900" loading="lazy">
+                <div class="nk-screenshot__caption">
+                    <h3>Fingerprint audit</h3>
+                    <p>A → B → A проверка показывает verified/partial/unchanged/unstable вместо маркетинговых обещаний.</p>
+                </div>
+            </div>
+            <div class="nk-screenshot nk-reveal" style="transition-delay:160ms">
+                <img src="/img/neantik/proxy-privacy.svg" alt="NeAntik — proxy и приватность" width="1440" height="900" loading="lazy">
+                <div class="nk-screenshot__caption">
+                    <h3>Proxy и приватность</h3>
+                    <p>Proxy на профиль, Keychain для паролей, локальные данные и выключенная в Direct-сборке телеметрия.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    {{-- ═══ PROBLEM ═══ --}}
+    <section class="section nk-reveal" id="neantik-problem">
+        <div class="section-head"><h2>Профили должны разделять контексты, а&nbsp;не&nbsp;усложнять работу</h2></div>
+        <div class="nk-problem">
+            <p>Режим инкогнито не&nbsp;создаёт новое устройство для сайта. Cookies можно очистить, но&nbsp;Canvas, WebGL, Audio, GPU, timezone и&nbsp;другие сигналы остаются связанными с&nbsp;тем&nbsp;же браузером и&nbsp;Mac.</p>
+            <p>Большие антидетект-платформы решают эту задачу вместе с&nbsp;облаком, командами, API, RPA и&nbsp;десятками настроек. Это полезно для масштабных операций, но&nbsp;лишнее, если нужны несколько постоянных локальных контекстов на&nbsp;одном Mac.</p>
+            <p>NeAntik оставляет только основу: профиль, proxy, встроенный Chromium, стабильная identity и&nbsp;проверка результата.</p>
+        </div>
+    </section>
+
+    {{-- ═══ KILLER FEATURE: A→B→A ═══ --}}
+    <section class="section nk-reveal" id="neantik-check">
+        <div class="section-head"><h2>Настроить недостаточно — нужно измерить</h2></div>
+        <p class="muted" style="max-width:640px; margin-bottom:1rem;">Встроенный Chromium получает identity профиля. Затем NeAntik запускает локальную проверку A → B → A: сравнивает два профиля и повторно проверяет первый.</p>
+
+        <div class="nk-aba-demo" x-data="nkAba()">
+            <div class="nk-aba">
+                <div class="nk-aba__node" :class="{'nk-aba__node--active': step===1, 'nk-aba__node--done': step>1}">
+                    <span class="nk-aba__node-label">Profile A</span>
+                    <span class="nk-aba__node-sub" x-text="step===1 ? 'measuring…' : step>1 ? 'stable' : 'idle'" x-show="!done"></span>
+                    <span class="nk-aba__node-sub" x-show="done" style="color:var(--money)">stable</span>
+                </div>
+                <span class="nk-aba__arrow" :class="{'nk-aba__arrow--active': step>=2}" aria-hidden="true">→</span>
+                <div class="nk-aba__node" :class="{'nk-aba__node--active': step===2, 'nk-aba__node--done': step>2}">
+                    <span class="nk-aba__node-label">Profile B</span>
+                    <span class="nk-aba__node-sub" x-text="step===2 ? 'measuring…' : step>2 ? 'distinct' : 'idle'" x-show="!done"></span>
+                    <span class="nk-aba__node-sub" x-show="done" style="color:var(--accent-dim)">distinct</span>
+                </div>
+                <span class="nk-aba__arrow" :class="{'nk-aba__arrow--active': step>=3}" aria-hidden="true">→</span>
+                <div class="nk-aba__node" :class="{'nk-aba__node--active': step===3, 'nk-aba__node--done': done}">
+                    <span class="nk-aba__node-label">Profile A</span>
+                    <span class="nk-aba__node-sub" x-text="step===3 ? 're-checking…' : done ? 'stable' : 'idle'" x-show="!done"></span>
+                    <span class="nk-aba__node-sub" x-show="done" style="color:var(--money)">stable</span>
+                </div>
+                <span class="nk-aba__verdict" :class="{'is-visible': done, 'nk-aba__verdict--verified': done}">verified</span>
+            </div>
+            <button class="nk-aba__btn" @click="run()" :disabled="running" x-text="done ? '↻ Повторить' : running ? 'Проверяю…' : '▶ Запустить проверку'"></button>
+        </div>
+
+        <p style="font-size:.88rem; color:var(--ink-2); margin:.5rem 0;">Если A и B отличаются, но A нестабилен между запусками — fingerprint ненадёжен. Только различающийся <em>и</em> повторяемый результат получает verdict <strong style="font-family:var(--mono);">verified</strong>.</p>
+
+        <div class="nk-surfaces">
+            @foreach ($surfaces as $s)
+                <span class="chip">{{ $s }}</span>
+            @endforeach
+        </div>
+    </section>
+
+    {{-- ═══ LOCAL-FIRST ═══ --}}
+    <section class="section nk-reveal" id="neantik-local">
+        <div class="section-head"><h2>Ваши профили остаются на&nbsp;вашем Mac</h2></div>
+        <div class="nk-local-cards">
+            <div class="card nk-local-card nk-reveal" style="transition-delay:0ms">
+                <span class="nk-local-card__icon" aria-hidden="true">SESSION</span>
+                <h3>Отдельные сессии</h3>
+                <p>Cookies, localStorage, cache и авторизация каждого профиля изолированы в отдельных папках.</p>
+            </div>
+            <div class="card nk-local-card nk-reveal" style="transition-delay:60ms">
+                <span class="nk-local-card__icon" aria-hidden="true">NETWORK</span>
+                <h3>Отдельная сеть</h3>
+                <p>Direct, HTTP, HTTPS и SOCKS5 proxy назначается профилю. Проверка exit IP и согласование timezone.</p>
+            </div>
+            <div class="card nk-local-card nk-reveal" style="transition-delay:120ms">
+                <span class="nk-local-card__icon" aria-hidden="true">KEYCHAIN</span>
+                <h3>macOS security</h3>
+                <p>Пароли прокси в Keychain, owner-only файлы, proxy credentials не попадают в command line.</p>
+            </div>
+        </div>
+    </section>
+
+    {{-- ═══ WHY NEANTIK ═══ --}}
+    <section class="section nk-reveal" id="neantik-why">
+        <div class="section-head"><h2>Почему NeAntik</h2></div>
+        <div class="nk-features">
+            <div class="card nk-feat nk-reveal" style="transition-delay:0ms">
+                <div class="nk-feat__icon" aria-hidden="true">◆</div>
+                <h3>Нативный для Mac</h3>
+                <p>SwiftUI, ARM64-only. Без Electron, Tauri, Node.js. Менеджер + встроенный Chromium — всё в одном приложении.</p>
+            </div>
+            <div class="card nk-feat nk-reveal" style="transition-delay:60ms">
+                <div class="nk-feat__icon" aria-hidden="true">⊘</div>
+                <h3>Без облака и аккаунта</h3>
+                <p>Профили хранятся на Mac. Нет синхронизации, нет телеметрии, нет сервера. История, cookies, URL — не передаются.</p>
+            </div>
+            <div class="card nk-feat nk-reveal" style="transition-delay:120ms">
+                <div class="nk-feat__icon" aria-hidden="true">⊞</div>
+                <h3>Chromium {{ $runtimeMajor }} из коробки</h3>
+                <p>Встроенный Chromium {{ $runtimeVersion }} ARM64 с Metal. Внешний Chrome не нужен — скачал, открыл, работаешь.</p>
+            </div>
+            <div class="card nk-feat nk-reveal" style="transition-delay:180ms">
+                <div class="nk-feat__icon" aria-hidden="true">↻</div>
+                <h3>Proxy + leak control</h3>
+                <p>Direct, HTTP/HTTPS, SOCKS5. Проверка exit IP, блокировка DNS fallback, отключение QUIC и non-proxied WebRTC.</p>
+            </div>
+        </div>
+    </section>
+
+    {{-- ═══ HOW IT WORKS ═══ --}}
+    <section class="section nk-reveal" id="neantik-how">
+        <div class="section-head"><h2>Четыре шага</h2></div>
+        <div class="nk-steps">
+            <div class="card nk-step nk-reveal" style="transition-delay:0ms">
+                <h3>Скачайте и установите</h3>
+                <p>Откройте DMG и перетащите NeAntik.app в папку «Программы». ZIP доступен как альтернативный формат.</p>
+            </div>
+            <div class="card nk-step nk-reveal" style="transition-delay:80ms">
+                <h3>Создайте профиль</h3>
+                <p>Откройте NeAntik. Имя, цвет, стартовая страница — приложение создаст изолированное хранилище.</p>
+            </div>
+            <div class="card nk-step nk-reveal" style="transition-delay:160ms">
+                <h3>Подключите proxy</h3>
+                <p>Direct, HTTP/HTTPS или SOCKS5. Проверьте exit IP, страну и timezone одной кнопкой.</p>
+            </div>
+            <div class="card nk-step nk-reveal" style="transition-delay:240ms">
+                <h3>Запустите и проверьте</h3>
+                <p>Нажмите Launch — откроется встроенный Chromium. Запустите A → B → A для проверки fingerprint.</p>
+            </div>
+        </div>
+    </section>
+
+    {{-- ═══ PRIVACY ═══ --}}
+    <section class="section nk-reveal" id="neantik-privacy">
+        <div class="section-head"><h2>Что хранится локально, что не отправляется</h2></div>
+        <div class="nk-privacy">
+            <div class="card nk-privacy-card nk-reveal" style="transition-delay:0ms">
+                <span class="nk-privacy-card__icon nk-privacy-card__icon--green" aria-hidden="true">LOCAL</span>
+                <h3>Хранится на Mac</h3>
+                <ul>
+                    <li>Данные профилей (Application Support)</li>
+                    <li>Cookies, localStorage, cache</li>
+                    <li>История посещений и URL</li>
+                    <li>Proxy-пароли (macOS Keychain)</li>
+                    <li>Отчёты fingerprint check</li>
+                </ul>
+            </div>
+            <div class="card nk-privacy-card nk-reveal" style="transition-delay:60ms">
+                <span class="nk-privacy-card__icon nk-privacy-card__icon--muted" aria-hidden="true">NOT SENT</span>
+                <h3>Не передаётся никуда</h3>
+                <ul>
+                    <li>Телеметрия отключена</li>
+                    <li>Нет облачной синхронизации</li>
+                    <li>Нет аналитики использования</li>
+                    <li>Нет аккаунта и регистрации</li>
+                    <li>Нет серверов NeAntik</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    {{-- ═══ PROOF ═══ --}}
+    <section class="section nk-reveal" id="neantik-proof">
+        <div class="section-head"><h2>Что уже проверено</h2></div>
+        <div class="nk-proof">
+            @foreach ($proofItems as $pi)
+                <div class="card nk-proof-stat nk-reveal">
+                    <span class="nk-proof-stat__num">{!! $pi['num'] !!}</span>
+                    <span class="nk-proof-stat__label">{!! $pi['label'] !!}</span>
+                </div>
+            @endforeach
+        </div>
+        <p class="muted" style="margin-top:1rem; font-size:.82rem; max-width:38rem;">Swift strict-concurrency, ARM64-only release, Developer ID + Apple notarization, Gatekeeper verified, owner-only metadata, PID reuse protection, proxy injection tests.</p>
+
+        <div class="nk-sha">
+            <strong>DMG SHA-256:</strong> {{ $dmgSha256 }}<br>
+            <strong>ZIP SHA-256:</strong> {{ $zipSha256 }}
+        </div>
+    </section>
+
+    {{-- ═══ COMPARISON ═══ --}}
+    <section class="section nk-reveal" id="neantik-compare">
+        <div class="section-head"><h2>NeAntik vs антидетект-платформы</h2></div>
+        <div class="nk-compare-wrap">
+            <table class="nk-compare">
+                <thead>
+                    <tr>
+                        @foreach ($compareHeaders as $h)
+                            <th>{{ $h }}</th>
+                        @endforeach
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($compare as $row)
+                        <tr>
+                            <th scope="row">{{ $row[0] }}</th>
+                            @for ($i = 1; $i < count($row); $i++)
+                                <td>{{ $row[$i] }}</td>
+                            @endfor
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        <p class="muted" style="margin-top:.8rem; font-size:.78rem;">NeAntik не заменяет командные функции больших платформ. Он для другого: быстрые локальные профили на Apple Silicon без инфраструктуры вокруг.</p>
+    </section>
+
+    {{-- ═══ DISTRIBUTION ═══ --}}
+    <section class="section nk-reveal" id="neantik-editions">
+        <div class="section-head"><h2>Direct Distribution для macOS</h2></div>
+        <div class="nk-editions">
+            <div class="card nk-edition">
+                <span class="nk-edition__badge nk-edition__badge--direct">Direct</span>
+                <h3>Одна полноценная версия</h3>
+                <p>NeAntik распространяется с сайта и GitHub. В приложение встроен Chromium {{ $runtimeMajor }}, используются отдельные каталоги данных и fingerprint identity. Сборка подписана Developer ID, нотарифицирована Apple и проверена Gatekeeper.</p>
+            </div>
+        </div>
+    </section>
+
+    {{-- ═══ HONEST BOUNDARY ═══ --}}
+    <section class="section nk-reveal" id="neantik-boundary">
+        <div class="nk-boundary">
+            <p class="nk-boundary__title">Честный public alpha</p>
+            <p>NeAntik — рабочий инструмент на стадии public alpha. Встроенный Chromium {{ $runtimeMajor }} с Metal работает и проходит проверку A→B→A. Но это альфа: возможны баги, интерфейс меняется между релизами, профили могут потребовать миграцию при обновлении.</p>
+            <p>NeAntik не гарантирует анонимность и не обходит правила сайтов. Proxy, аккаунты, поведение и расширения могут связывать сессии. Инструмент уменьшает пересечение профилей и даёт способ это измерить — но ответственность за использование остаётся на пользователе.</p>
+        </div>
+    </section>
+
+    {{-- ═══ CHANGELOG ═══ --}}
+    <section class="section nk-reveal" id="neantik-changelog">
+        <div class="section-head"><h2>Changelog</h2></div>
+        <div class="nk-changelog">
+            @foreach ($changelog as $rel)
+                <div class="nk-release">
+                    <div class="nk-release__head">
+                        <span class="nk-release__ver">{{ $rel['ver'] }}</span>
+                        @if (!empty($rel['label']))
+                            <span class="nk-release__label">{{ $rel['label'] }}</span>
+                        @endif
+                        <span class="nk-release__date">build {{ $rel['build'] }} · {{ $rel['date'] }}</span>
+                    </div>
+                    <ul class="nk-release__list">
+                        @foreach ($rel['items'] as $item)
+                            <li>{{ $item }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endforeach
+        </div>
+    </section>
+
+    {{-- ═══ FAQ ═══ --}}
+    <section class="section nk-reveal" id="neantik-faq">
+        <div class="section-head"><h2>Вопросы и ответы</h2></div>
+        @foreach ($faqs as $f)
+            <div class="nk-faq-item" x-data="{open:false}" :class="{'is-open':open}">
+                <button class="nk-faq-item__q" type="button" @click="open=!open" :aria-expanded="open">{{ $f['q'] }}</button>
+                <div class="nk-faq-item__a" role="region">
+                    <div class="nk-faq-item__a-inner">
+                        <p>{{ $f['a'] }}</p>
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </section>
+
+    {{-- ═══ FINAL CTA ═══ --}}
+    <section class="section nk-reveal" style="text-align:center; padding:2.5rem 0;">
+        <h2 style="font-size:1.3rem; margin:0 0 .5rem;">Начните с чистого профиля</h2>
+        <p class="muted" style="margin:0 0 1.25rem; max-width:480px; margin-left:auto; margin-right:auto;">Скачайте, создайте профиль, нажмите Launch. Встроенный Chromium, без аккаунта, без облака.</p>
+        <div class="hero-actions" style="justify-content:center;">
+            <a class="btn btn-primary" href="{{ $dmgDownloadUrl }}">Скачать DMG</a>
+            <a class="btn btn-ghost" href="{{ $zipDownloadUrl }}">Скачать ZIP</a>
+            <a class="btn btn-ghost" href="{{ $githubReleaseUrl }}" rel="noopener">GitHub</a>
+        </div>
+        <div class="nk-security" style="justify-content:center; margin-top:.75rem;">
+            <span class="chip chip--verified">Developer ID</span>
+            <span class="chip chip--verified">Apple Notarized</span>
+            <span class="chip chip--verified">SHA-256 verified</span>
+        </div>
+    </section>
+
+    <script>
+    (function () {
+        if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            var obs = new IntersectionObserver(function (entries) {
+                entries.forEach(function (e) {
+                    if (e.isIntersecting) { e.target.classList.add('is-visible'); obs.unobserve(e.target); }
+                });
+            }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
+            document.querySelectorAll('.nk-reveal').forEach(function (el) { obs.observe(el); });
+        } else {
+            document.querySelectorAll('.nk-reveal').forEach(function (el) { el.classList.add('is-visible'); });
+        }
+    })();
+
+    document.addEventListener('alpine:init', function () {
+        Alpine.data('nkAba', function () {
+            return {
+                step: 0,
+                running: false,
+                done: false,
+                run: function () {
+                    if (this.running) return;
+                    this.step = 0;
+                    this.done = false;
+                    this.running = true;
+                    var self = this;
+                    setTimeout(function () { self.step = 1; }, 200);
+                    setTimeout(function () { self.step = 2; }, 900);
+                    setTimeout(function () { self.step = 3; }, 1600);
+                    setTimeout(function () { self.done = true; self.running = false; }, 2300);
+                }
+            };
+        });
+    });
+    </script>
+@endsection

--- a/ops/affpapa/install-server-batch.sh
+++ b/ops/affpapa/install-server-batch.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Root-only one-time installer for the restricted NeAntik AffPapa channel.
+set -Eeuo pipefail
+
+[[ "$(id -u)" -eq 0 ]] || {
+    echo "Run as root." >&2
+    exit 1
+}
+[[ $# -eq 1 ]] || {
+    echo "Usage: $0 <staged-source-dir>" >&2
+    exit 2
+}
+
+STAGED=$(readlink -f "$1")
+LIVE_ROOT="/var/www/hrband"
+BLADE_LIVE="$LIVE_ROOT/resources/views/affpapa/neantik.blade.php"
+CONTENT_LIVE="$LIVE_ROOT/public/neantik/content.json"
+RELEASE_LIVE="$LIVE_ROOT/public/neantik/release.json"
+SUDOERS_LIVE="/etc/sudoers.d/neantik-deploy"
+AUTHORIZED_KEYS="/home/neantik-deploy/.ssh/authorized_keys"
+BACKUP_ROOT="$LIVE_ROOT/storage/app/codex-backups"
+TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+BACKUP="$BACKUP_ROOT/neantik-final-access-$TIMESTAMP"
+CONTENT_EXISTED=0
+
+required=(
+    neantik-release-deploy
+    neantik-release-rollback
+    neantik-release-status
+    neantik-release-abort
+    neantik-upload
+    neantik-ssh-dispatcher
+    neantik-validate-release
+    neantik.blade.php
+    content.json
+    neantik-deploy.sudoers
+)
+for filename in "${required[@]}"; do
+    [[ -f "$STAGED/$filename" ]] || {
+        echo "Missing staged file: $filename" >&2
+        exit 1
+    }
+done
+
+for script in \
+    neantik-release-deploy \
+    neantik-release-rollback \
+    neantik-release-status \
+    neantik-release-abort \
+    neantik-upload \
+    neantik-ssh-dispatcher; do
+    bash -n "$STAGED/$script"
+done
+python3 -c \
+    "compile(open('$STAGED/neantik-validate-release', encoding='utf-8').read(), 'neantik-validate-release', 'exec')"
+php -l "$STAGED/neantik.blade.php" >/dev/null
+python3 -m json.tool "$STAGED/content.json" >/dev/null
+visudo -cf "$STAGED/neantik-deploy.sudoers" >/dev/null
+
+mkdir -p "$BACKUP/sbin"
+cp -a /usr/local/sbin/neantik-* "$BACKUP/sbin/"
+cp -a "$BLADE_LIVE" "$BACKUP/neantik.blade.php"
+cp -a "$RELEASE_LIVE" "$BACKUP/release.json"
+cp -a "$SUDOERS_LIVE" "$BACKUP/neantik-deploy.sudoers"
+cp -a "$AUTHORIZED_KEYS" "$BACKUP/authorized_keys"
+if [[ -f "$CONTENT_LIVE" ]]; then
+    CONTENT_EXISTED=1
+    cp -a "$CONTENT_LIVE" "$BACKUP/content.json"
+fi
+BEFORE_RELEASE_SHA=$(sha256sum "$RELEASE_LIVE" | cut -d' ' -f1)
+
+restore_install() {
+    local status=$?
+    echo "Install failed; restoring previous server files." >&2
+    cp -a "$BACKUP/sbin/"neantik-* /usr/local/sbin/ || true
+    cp -a "$BACKUP/neantik.blade.php" "$BLADE_LIVE" || true
+    cp -a "$BACKUP/neantik-deploy.sudoers" "$SUDOERS_LIVE" || true
+    if [[ "$CONTENT_EXISTED" -eq 1 ]]; then
+        cp -a "$BACKUP/content.json" "$CONTENT_LIVE" || true
+    else
+        rm -f "$CONTENT_LIVE"
+    fi
+    cd "$LIVE_ROOT"
+    sudo -u deploy php artisan view:clear >/dev/null 2>&1 || true
+    sudo -u deploy php artisan view:cache >/dev/null 2>&1 || true
+    exit "$status"
+}
+trap restore_install ERR
+
+install -m 755 -o root -g root \
+    "$STAGED/neantik-release-deploy" \
+    "$STAGED/neantik-release-rollback" \
+    "$STAGED/neantik-release-status" \
+    "$STAGED/neantik-release-abort" \
+    "$STAGED/neantik-upload" \
+    "$STAGED/neantik-ssh-dispatcher" \
+    "$STAGED/neantik-validate-release" \
+    /usr/local/sbin/
+install -m 440 -o root -g root \
+    "$STAGED/neantik-deploy.sudoers" \
+    "$SUDOERS_LIVE"
+visudo -cf "$SUDOERS_LIVE" >/dev/null
+
+content_tmp=$(mktemp "$CONTENT_LIVE.install-XXXXXX")
+install -m 644 -o deploy -g deploy "$STAGED/content.json" "$content_tmp"
+mv -f "$content_tmp" "$CONTENT_LIVE"
+
+blade_tmp=$(mktemp "$BLADE_LIVE.install-XXXXXX")
+install -m 644 -o root -g root "$STAGED/neantik.blade.php" "$blade_tmp"
+mv -f "$blade_tmp" "$BLADE_LIVE"
+
+cd "$LIVE_ROOT"
+sudo -u deploy php artisan view:clear >/dev/null
+sudo -u deploy php artisan view:cache >/dev/null
+
+AFTER_RELEASE_SHA=$(sha256sum "$RELEASE_LIVE" | cut -d' ' -f1)
+[[ "$AFTER_RELEASE_SHA" == "$BEFORE_RELEASE_SHA" ]] || {
+    echo "Live release.json changed during access installation." >&2
+    false
+}
+
+# The origin vhost has an incomplete local CA chain. This exception is limited
+# to affpapa.org pinned to loopback; external client verification stays strict.
+curl -fsS --insecure --resolve "affpapa.org:443:127.0.0.1" \
+    "https://affpapa.org/neantik" >/dev/null
+served_content=$(mktemp /tmp/neantik-content-install-XXXXXX)
+curl -fsS --insecure --resolve "affpapa.org:443:127.0.0.1" \
+    "https://affpapa.org/neantik/content.json" >"$served_content"
+cmp -s "$served_content" "$CONTENT_LIVE"
+
+trap - ERR
+echo "PASS: final NeAntik access batch installed."
+echo "Backup: $BACKUP"
+sha256sum /usr/local/sbin/neantik-*

--- a/ops/affpapa/neantik-deploy.sudoers
+++ b/ops/affpapa/neantik-deploy.sudoers
@@ -1,0 +1,11 @@
+# Install as /etc/sudoers.d/neantik-deploy with mode 0440.
+Defaults:neantik-deploy env_reset
+neantik-deploy ALL=(root) NOPASSWD: /usr/local/sbin/neantik-release-status ""
+neantik-deploy ALL=(root) NOPASSWD: /usr/local/sbin/neantik-release-deploy ""
+neantik-deploy ALL=(root) NOPASSWD: /usr/local/sbin/neantik-release-deploy --check
+neantik-deploy ALL=(root) NOPASSWD: /usr/local/sbin/neantik-release-deploy --dry-run
+neantik-deploy ALL=(root) NOPASSWD: /usr/local/sbin/neantik-release-abort ""
+neantik-deploy ALL=(root) NOPASSWD: /usr/local/sbin/neantik-release-rollback ""
+neantik-deploy ALL=(root) NOPASSWD: /usr/local/sbin/neantik-release-rollback --check
+neantik-deploy ALL=(root) NOPASSWD: /usr/local/sbin/neantik-release-rollback --dry-run
+neantik-deploy ALL=(root) NOPASSWD: /usr/local/sbin/neantik-upload *

--- a/ops/affpapa/server/neantik-release-abort
+++ b/ops/affpapa/server/neantik-release-abort
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Clear only the restricted NeAntik staging directory.
+set -euo pipefail
+
+STAGING="/var/www/hrband/storage/app/neantik-release-staging"
+LOG="/var/log/neantik-deploy.log"
+LOCKFILE="/var/lock/neantik-deploy.lock"
+
+log_entry() {
+    printf '%s | %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "$LOG"
+}
+
+[[ $# -eq 0 ]] || {
+    echo "Usage: neantik-release-abort" >&2
+    exit 2
+}
+[[ -d "$STAGING" ]] || {
+    echo "FAIL: staging directory does not exist" >&2
+    exit 1
+}
+
+exec 9>"$LOCKFILE"
+flock -w 30 9 || {
+    echo "FAIL: deploy, rollback, or upload is in progress" >&2
+    exit 1
+}
+
+before=$(find "$STAGING" -mindepth 1 -maxdepth 1 | wc -l)
+find "$STAGING" -mindepth 1 -maxdepth 1 -delete
+after=$(find "$STAGING" -mindepth 1 -maxdepth 1 | wc -l)
+[[ "$after" -eq 0 ]] || {
+    echo "FAIL: staging cleanup is incomplete" >&2
+    exit 1
+}
+
+log_entry "STAGING ABORT: removed $before entries (user=${SUDO_USER:-?})"
+echo "OK: staging cleared ($before entries removed)"

--- a/ops/affpapa/server/neantik-release-deploy
+++ b/ops/affpapa/server/neantik-release-deploy
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# neantik-release-deploy — deploy NeAntik release from staging snapshot.
+# Root-owned, /usr/local/sbin/neantik-release-deploy.
+# Uses flock, root-owned immutable snapshot, atomic publish, auto-rollback.
+# Canonical schema: runtime, source, artifacts[].
+# Blade is root-owned and NOT part of the deploy channel.
+set -euo pipefail
+
+LIVE_ROOT="/var/www/hrband"
+STAGING="/var/www/hrband/storage/app/neantik-release-staging"
+BACKUPS="/var/www/hrband/storage/app/neantik-release-backups"
+LOG="/var/log/neantik-deploy.log"
+LOCKFILE="/var/lock/neantik-deploy.lock"
+RELEASE_JSON_LIVE="$LIVE_ROOT/public/neantik/release.json"
+CONTENT_JSON_LIVE="$LIVE_ROOT/public/neantik/content.json"
+DOWNLOADS_LIVE="$LIVE_ROOT/public/neantik/downloads"
+VALIDATOR="/usr/local/sbin/neantik-validate-release"
+# The origin vhost has an incomplete local CA chain. TLS verification is
+# bypassed only for the host pinned to loopback; public-client checks remain
+# strict in scripts/neantik-affpapa-release.
+CURL_RESOLVE=(--insecure --resolve "affpapa.org:443:127.0.0.1")
+
+CHECK_MODE=0
+DRY_RUN=0
+case "${1:-}" in
+    --check)   CHECK_MODE=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    "")        ;;
+    *)         echo "Usage: neantik-release-deploy [--check|--dry-run]" >&2; exit 2 ;;
+esac
+
+log_entry() {
+    printf '%s | %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "$LOG"
+}
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    log_entry "DEPLOY FAIL: $1 (user=${SUDO_USER:-?})"
+    exit 1
+}
+
+# Helper: read artifact field from release.json via Python
+rj_artifact() {
+    local rj="$1" fmt="$2" field="$3"
+    python3 -c "
+import json, sys
+arts = json.load(open('$rj'))['artifacts']
+for a in arts:
+    if a['format'] == '$fmt':
+        print(a['$field'])
+        sys.exit(0)
+sys.exit(1)
+"
+}
+
+# --- flock: only one deploy/rollback at a time ---
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+    fail "another deploy/rollback is running (lock: $LOCKFILE)"
+fi
+
+# --- Staging must have release.json ---
+[[ -f "$STAGING/release.json" ]] || fail "release.json not found in staging"
+
+# --- Create root-owned snapshot (transaction directory) ---
+SNAPSHOT=$(mktemp -d /tmp/neantik-snapshot-XXXXXX)
+chmod 700 "$SNAPSHOT"
+chown root:root "$SNAPSHOT"
+trap 'rm -rf "$SNAPSHOT"' EXIT
+
+# Safe copy: only regular files, no symlinks/FIFO/devices, check nlink, owner, perms, size
+DEPLOY_UID=$(id -u neantik-deploy)
+DEPLOY_GID=$(id -g neantik-deploy)
+MAX_BINARY=$((300 * 1024 * 1024))
+
+for entry in "$STAGING"/*; do
+    [[ -e "$entry" ]] || continue
+    bname=$(basename "$entry")
+
+    [[ "$bname" =~ ^\. ]] && fail "hidden file in staging: $bname"
+
+    ftype=$(stat -c %F "$entry")
+    [[ "$ftype" == "regular file" ]] || fail "non-regular file in staging: $bname ($ftype)"
+
+    [[ -L "$entry" ]] && fail "symlink in staging: $bname"
+
+    nlink=$(stat -c %h "$entry")
+    [[ "$nlink" -eq 1 ]] || fail "hardlink count != 1 for $bname (nlink=$nlink)"
+
+    fuid=$(stat -c %u "$entry")
+    fgid=$(stat -c %g "$entry")
+    [[ "$fuid" -eq "$DEPLOY_UID" ]] || fail "$bname: owner uid $fuid != expected $DEPLOY_UID"
+    [[ "$fgid" -eq "$DEPLOY_GID" ]] || fail "$bname: owner gid $fgid != expected $DEPLOY_GID"
+
+    perms=$(stat -c %a "$entry")
+    case "$perms" in
+        600|640) ;;
+        *) fail "$bname: unsafe permissions $perms (expected 600 or 640)" ;;
+    esac
+
+    fsize=$(stat -c %s "$entry")
+    case "$bname" in
+        release.json)  [[ "$fsize" -le $((16 * 1024)) ]] || fail "$bname too large: $fsize" ;;
+        content.json)  [[ "$fsize" -le $((64 * 1024)) ]] || fail "$bname too large: $fsize" ;;
+        *.sha256)      [[ "$fsize" -le 256 ]] || fail "$bname too large: $fsize" ;;
+        *.dmg|*.zip)   [[ "$fsize" -le "$MAX_BINARY" ]] || fail "$bname too large: $fsize" ;;
+        *)             fail "unexpected file: $bname" ;;
+    esac
+
+    pre_stat=$(stat -c '%s %Y' "$entry")
+    pre_sha=$(sha256sum "$entry" | cut -d' ' -f1)
+
+    install -m 600 -o root -g root "$entry" "$SNAPSHOT/$bname"
+
+    post_stat=$(stat -c '%s %Y' "$entry")
+    post_sha=$(sha256sum "$entry" | cut -d' ' -f1)
+
+    if [[ "$pre_stat" != "$post_stat" ]]; then
+        fail "$bname: file changed during copy (stat mismatch)"
+    fi
+    if [[ "$pre_sha" != "$post_sha" ]]; then
+        fail "$bname: file changed during copy (SHA mismatch)"
+    fi
+
+    snap_sha=$(sha256sum "$SNAPSHOT/$bname" | cut -d' ' -f1)
+    if [[ "$snap_sha" != "$pre_sha" ]]; then
+        fail "$bname: snapshot copy SHA mismatch"
+    fi
+done
+
+# --- Run Python validator on snapshot ---
+python3 "$VALIDATOR" "$SNAPSHOT" "$RELEASE_JSON_LIVE" || fail "release.json validation failed"
+
+# --- Extract version from snapshot ---
+VERSION=$(python3 -c "import json; print(json.load(open('$SNAPSHOT/release.json'))['version'])")
+BUILD=$(python3 -c "import json; print(json.load(open('$SNAPSHOT/release.json'))['build'])")
+
+echo "=== NeAntik Deploy: v$VERSION (build $BUILD) ==="
+
+# --- Check / dry-run mode ---
+if [[ "$CHECK_MODE" -eq 1 ]]; then
+    echo ""
+    echo "=== CHECK MODE — all validations passed ==="
+    log_entry "DEPLOY CHECK: v$VERSION passed all validations (user=${SUDO_USER:-?})"
+    exit 0
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo ""
+    echo "=== DRY-RUN — all validations passed, no changes made ==="
+    log_entry "DEPLOY DRY-RUN: v$VERSION passed all validations (user=${SUDO_USER:-?})"
+    exit 0
+fi
+
+# --- Block overwriting same version with different bytes ---
+if [[ -f "$RELEASE_JSON_LIVE" ]]; then
+    LIVE_VER=$(python3 -c "import json; print(json.load(open('$RELEASE_JSON_LIVE'))['version'])" 2>/dev/null || echo "")
+    if [[ "$LIVE_VER" == "$VERSION" ]]; then
+        fail "cannot overwrite published version $VERSION — publish a new version instead"
+    fi
+fi
+
+# ===================================================================
+# DEPLOYMENT — from this point, any failure triggers full rollback
+# ===================================================================
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+BACKUP_DIR="$BACKUPS/$TS-v$VERSION"
+mkdir "$BACKUP_DIR"
+chown root:root "$BACKUP_DIR"
+chmod 700 "$BACKUP_DIR"
+
+backup_file() {
+    local src="$1"
+    if [[ -f "$src" ]]; then
+        local dest
+        dest="$BACKUP_DIR/$(basename "$src")"
+        cp -p "$src" "$dest"
+        chown root:root "$dest"
+        chmod 600 "$dest"
+    fi
+}
+
+backup_file "$RELEASE_JSON_LIVE"
+backup_file "$CONTENT_JSON_LIVE"
+for f in "$DOWNLOADS_LIVE"/NeAntik-*; do
+    [[ -f "$f" ]] && backup_file "$f"
+done
+(cd "$BACKUP_DIR" && sha256sum -- * > backup.sha256)
+chown root:root "$BACKUP_DIR/backup.sha256"
+chmod 600 "$BACKUP_DIR/backup.sha256"
+echo "  OK: backup at $BACKUP_DIR"
+
+declare -a PUBLISHED_FILES=()
+
+do_rollback() {
+    echo "!!! ROLLING BACK !!!" >&2
+    log_entry "DEPLOY ROLLBACK START: v$VERSION (user=${SUDO_USER:-?})"
+
+    for bfile in "$BACKUP_DIR"/*; do
+        [[ -f "$bfile" ]] || continue
+        local bname
+        bname=$(basename "$bfile")
+
+        local dest=""
+        case "$bname" in
+            release.json) dest="$RELEASE_JSON_LIVE" ;;
+            content.json) dest="$CONTENT_JSON_LIVE" ;;
+            NeAntik-*)    dest="$DOWNLOADS_LIVE/$bname" ;;
+            *)            continue ;;
+        esac
+
+        local tmprest
+        tmprest=$(mktemp "${dest}.rollback-XXXXXX")
+        cp -p "$bfile" "$tmprest"
+        chown deploy:deploy "$tmprest"
+        chmod 644 "$tmprest"
+        mv -f "$tmprest" "$dest"
+    done
+
+    for pf in "${PUBLISHED_FILES[@]}"; do
+        local pfname
+        pfname=$(basename "$pf")
+        if [[ ! -f "$BACKUP_DIR/$pfname" ]]; then
+            rm -f "$pf"
+        fi
+    done
+
+    log_entry "DEPLOY ROLLBACK COMPLETE: v$VERSION (user=${SUDO_USER:-?})"
+    echo "!!! ROLLBACK COMPLETE !!!" >&2
+}
+
+publish_file() {
+    local src="$1"
+    local dest="$2"
+    local tmpfile
+    tmpfile=$(mktemp "${dest}.publish-XXXXXX")
+    cp -p "$src" "$tmpfile"
+    chown deploy:deploy "$tmpfile"
+    chmod 644 "$tmpfile"
+    mv -f "$tmpfile" "$dest"
+    PUBLISHED_FILES+=("$dest")
+}
+
+# --- Publish immutable downloads first ---
+for f in "$SNAPSHOT"/NeAntik-*; do
+    [[ -f "$f" ]] || continue
+    publish_file "$f" "$DOWNLOADS_LIVE/$(basename "$f")"
+    echo "  OK: $(basename "$f") published"
+done
+
+# --- Publish page data, then release.json as the atomic public pointer ---
+publish_file "$SNAPSHOT/content.json" "$CONTENT_JSON_LIVE"
+echo "  OK: content.json published"
+publish_file "$SNAPSHOT/release.json" "$RELEASE_JSON_LIVE"
+echo "  OK: release.json published"
+
+# ===================================================================
+# SMOKE GATE — all failures are fatal and trigger rollback
+# ===================================================================
+echo ""
+echo "=== Smoke gate ==="
+
+# 1. Landing page 200
+HTTP_LAND=$(curl -sf "${CURL_RESOLVE[@]}" -o /dev/null -w '%{http_code}' "https://affpapa.org/neantik" 2>/dev/null || echo "000")
+if [[ "$HTTP_LAND" != "200" ]]; then
+    do_rollback
+    fail "landing page returned $HTTP_LAND (expected 200)"
+fi
+echo "  OK: landing 200"
+
+# 2. release.json 200 + content match
+SMOKE_RJ=$(mktemp /tmp/neantik-smoke-rj-XXXXXX)
+HTTP_RJ=$(curl -sf "${CURL_RESOLVE[@]}" -o "$SMOKE_RJ" -w '%{http_code}' "https://affpapa.org/neantik/release.json" 2>/dev/null || echo "000")
+if [[ "$HTTP_RJ" != "200" ]]; then
+    rm -f "$SMOKE_RJ"
+    do_rollback
+    fail "release.json returned $HTTP_RJ (expected 200)"
+fi
+SERVED_SHA=$(sha256sum "$SMOKE_RJ" | cut -d' ' -f1)
+PUBLISHED_SHA=$(sha256sum "$RELEASE_JSON_LIVE" | cut -d' ' -f1)
+rm -f "$SMOKE_RJ"
+if [[ "$SERVED_SHA" != "$PUBLISHED_SHA" ]]; then
+    do_rollback
+    fail "release.json served content does not match published file"
+fi
+echo "  OK: release.json 200, content matches"
+
+# 3. content.json 200 + content match
+SMOKE_CONTENT=$(mktemp /tmp/neantik-smoke-content-XXXXXX)
+HTTP_CONTENT=$(curl -sf "${CURL_RESOLVE[@]}" -o "$SMOKE_CONTENT" -w '%{http_code}' "https://affpapa.org/neantik/content.json" 2>/dev/null || echo "000")
+if [[ "$HTTP_CONTENT" != "200" ]]; then
+    rm -f "$SMOKE_CONTENT"
+    do_rollback
+    fail "content.json returned $HTTP_CONTENT (expected 200)"
+fi
+SERVED_CONTENT_SHA=$(sha256sum "$SMOKE_CONTENT" | cut -d' ' -f1)
+PUBLISHED_CONTENT_SHA=$(sha256sum "$CONTENT_JSON_LIVE" | cut -d' ' -f1)
+rm -f "$SMOKE_CONTENT"
+if [[ "$SERVED_CONTENT_SHA" != "$PUBLISHED_CONTENT_SHA" ]]; then
+    do_rollback
+    fail "content.json served content does not match published file"
+fi
+echo "  OK: content.json 200, content matches"
+
+# 4. Downloads: 206 Range + Content-Range with sizeBytes (via artifacts[])
+for fmt in dmg zip; do
+    DL_URL=$(rj_artifact "$RELEASE_JSON_LIVE" "$fmt" "url")
+    EXPECTED_SIZE=$(rj_artifact "$RELEASE_JSON_LIVE" "$fmt" "sizeBytes")
+
+    RANGE_RESP=$(curl -sf "${CURL_RESOLVE[@]}" -I -H "Range: bytes=0-0" "$DL_URL" 2>/dev/null || echo "")
+    HTTP_DL=$(echo "$RANGE_RESP" | grep -i "^HTTP/" | tail -1 | awk '{print $2}')
+    if [[ "$HTTP_DL" != "206" ]]; then
+        do_rollback
+        fail "$fmt download returned $HTTP_DL (expected 206 for Range request)"
+    fi
+
+    CONTENT_RANGE=$(echo "$RANGE_RESP" | grep -i "^content-range:" | tr -d '\r')
+    if [[ -z "$CONTENT_RANGE" ]]; then
+        do_rollback
+        fail "$fmt download missing Content-Range header"
+    fi
+
+    RANGE_TOTAL=$(echo "$CONTENT_RANGE" | grep -oP '/\K[0-9]+' || echo "0")
+    if [[ "$RANGE_TOTAL" != "$EXPECTED_SIZE" ]]; then
+        do_rollback
+        fail "$fmt Content-Range total $RANGE_TOTAL != sizeBytes $EXPECTED_SIZE"
+    fi
+    echo "  OK: $fmt 206, size $RANGE_TOTAL matches"
+done
+
+# 5. Local published SHA matches release.json (via artifacts[])
+for fmt in dmg zip; do
+    EXPECTED_HASH=$(rj_artifact "$RELEASE_JSON_LIVE" "$fmt" "sha256")
+    FNAME=$(rj_artifact "$RELEASE_JSON_LIVE" "$fmt" "filename")
+    ACTUAL_HASH=$(sha256sum "$DOWNLOADS_LIVE/$FNAME" | cut -d' ' -f1)
+    if [[ "$ACTUAL_HASH" != "$EXPECTED_HASH" ]]; then
+        do_rollback
+        fail "$FNAME: published SHA $ACTUAL_HASH != release.json $EXPECTED_HASH"
+    fi
+    echo "  OK: $FNAME SHA matches"
+done
+
+echo ""
+echo "=== DEPLOY COMPLETE: v$VERSION (build $BUILD) ==="
+
+rm -f "$STAGING"/*
+
+log_entry "DEPLOY OK: v$VERSION build $BUILD (user=${SUDO_USER:-?})"

--- a/ops/affpapa/server/neantik-release-rollback
+++ b/ops/affpapa/server/neantik-release-rollback
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# neantik-release-rollback — restore previous NeAntik release from backup.
+# Root-owned, /usr/local/sbin/neantik-release-rollback.
+# Uses flock, atomic file restore, mandatory smoke gate.
+# Any smoke failure → non-zero exit, no "ROLLBACK OK" logged.
+set -euo pipefail
+
+LIVE_ROOT="/var/www/hrband"
+BACKUPS="/var/www/hrband/storage/app/neantik-release-backups"
+LOG="/var/log/neantik-deploy.log"
+LOCKFILE="/var/lock/neantik-deploy.lock"
+RELEASE_JSON_LIVE="$LIVE_ROOT/public/neantik/release.json"
+CONTENT_JSON_LIVE="$LIVE_ROOT/public/neantik/content.json"
+DOWNLOADS_LIVE="$LIVE_ROOT/public/neantik/downloads"
+# The origin vhost has an incomplete local CA chain. TLS verification is
+# bypassed only for the host pinned to loopback.
+CURL_RESOLVE=(--insecure --resolve "affpapa.org:443:127.0.0.1")
+
+CHECK_MODE=0
+case "${1:-}" in
+    --check|--dry-run) CHECK_MODE=1 ;;
+    "")                ;;
+    *)                 echo "Usage: neantik-release-rollback [--check|--dry-run]" >&2; exit 2 ;;
+esac
+
+log_entry() {
+    printf '%s | %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "$LOG"
+}
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    log_entry "ROLLBACK FAIL: $1 (user=${SUDO_USER:-?})"
+    exit 1
+}
+
+# --- flock ---
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+    fail "another deploy/rollback is running (lock: $LOCKFILE)"
+fi
+
+# --- Find latest backup ---
+LATEST=""
+if [[ -d "$BACKUPS" ]]; then
+    LATEST=$(find "$BACKUPS" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null | sort -r | head -1)
+fi
+[[ -n "$LATEST" ]] || fail "no backups found in $BACKUPS"
+[[ -f "$LATEST/release.json" ]] || fail "backup has no release.json"
+[[ -f "$LATEST/content.json" ]] || fail "backup has no content.json"
+[[ -f "$LATEST/backup.sha256" ]] || fail "backup has no integrity manifest"
+(cd "$LATEST" && sha256sum -c backup.sha256 >/dev/null) || fail "backup integrity verification failed"
+
+RESTORE_VER=$(python3 -c "import json; print(json.load(open('$LATEST/release.json'))['version'])" 2>/dev/null || echo "?")
+
+echo "=== NeAntik Rollback ==="
+echo "Backup: $(basename "$LATEST")"
+echo "Restore to: v$RESTORE_VER"
+echo ""
+echo "Backup contents:"
+# shellcheck disable=SC2010
+ls -lh "$LATEST" | grep -v '^total' || true
+
+if [[ "$CHECK_MODE" -eq 1 ]]; then
+    echo ""
+    echo "=== DRY-RUN — no changes made ==="
+    log_entry "ROLLBACK DRY-RUN: would restore v$RESTORE_VER from $(basename "$LATEST") (user=${SUDO_USER:-?})"
+    exit 0
+fi
+
+echo ""
+echo "Restoring..."
+
+restore_file() {
+    local src="$1"
+    local dest="$2"
+    local tmpfile
+    tmpfile=$(mktemp "${dest}.restore-XXXXXX")
+    cp -p "$src" "$tmpfile"
+    chown deploy:deploy "$tmpfile"
+    chmod 644 "$tmpfile"
+    mv -f "$tmpfile" "$dest"
+}
+
+# Remove downloads introduced after this backup so rollback restores the exact
+# previous NeAntik artifact set while preserving every file present in backup.
+for current in "$DOWNLOADS_LIVE"/NeAntik-*; do
+    [[ -f "$current" ]] || continue
+    current_name=$(basename "$current")
+    if [[ ! -f "$LATEST/$current_name" ]]; then
+        rm -f -- "$current"
+        echo "  OK: removed post-backup artifact $current_name"
+    fi
+done
+
+# Restore downloads
+for f in "$LATEST"/NeAntik-*; do
+    [[ -f "$f" ]] || continue
+    restore_file "$f" "$DOWNLOADS_LIVE/$(basename "$f")"
+    echo "  OK: $(basename "$f") restored"
+done
+
+# Restore page data, then release.json as the public pointer.
+restore_file "$LATEST/content.json" "$CONTENT_JSON_LIVE"
+echo "  OK: content.json restored"
+restore_file "$LATEST/release.json" "$RELEASE_JSON_LIVE"
+echo "  OK: release.json restored"
+
+# === Mandatory smoke gate — failures are fatal ===
+echo ""
+echo "=== Post-rollback smoke ==="
+SMOKE_FAIL=0
+
+HTTP_LAND=$(curl -sf "${CURL_RESOLVE[@]}" -o /dev/null -w '%{http_code}' "https://affpapa.org/neantik" 2>/dev/null || echo "000")
+if [[ "$HTTP_LAND" != "200" ]]; then
+    echo "  CRITICAL: landing returned $HTTP_LAND after rollback" >&2
+    log_entry "ROLLBACK SMOKE FAIL: landing $HTTP_LAND (user=${SUDO_USER:-?})"
+    SMOKE_FAIL=1
+else
+    echo "  OK: landing 200"
+fi
+
+HTTP_RJ=$(curl -sf "${CURL_RESOLVE[@]}" -o /dev/null -w '%{http_code}' "https://affpapa.org/neantik/release.json" 2>/dev/null || echo "000")
+if [[ "$HTTP_RJ" != "200" ]]; then
+    echo "  CRITICAL: release.json returned $HTTP_RJ after rollback" >&2
+    log_entry "ROLLBACK SMOKE FAIL: release.json $HTTP_RJ (user=${SUDO_USER:-?})"
+    SMOKE_FAIL=1
+else
+    echo "  OK: release.json 200"
+fi
+
+HTTP_CONTENT=$(curl -sf "${CURL_RESOLVE[@]}" -o /dev/null -w '%{http_code}' "https://affpapa.org/neantik/content.json" 2>/dev/null || echo "000")
+if [[ "$HTTP_CONTENT" != "200" ]]; then
+    echo "  CRITICAL: content.json returned $HTTP_CONTENT after rollback" >&2
+    log_entry "ROLLBACK SMOKE FAIL: content.json $HTTP_CONTENT (user=${SUDO_USER:-?})"
+    SMOKE_FAIL=1
+else
+    echo "  OK: content.json 200"
+fi
+
+SERVED_RELEASE_SHA=$(curl -sf "${CURL_RESOLVE[@]}" "https://affpapa.org/neantik/release.json" | sha256sum | cut -d' ' -f1 || echo "missing")
+LOCAL_RELEASE_SHA=$(sha256sum "$RELEASE_JSON_LIVE" | cut -d' ' -f1)
+if [[ "$SERVED_RELEASE_SHA" != "$LOCAL_RELEASE_SHA" ]]; then
+    echo "  CRITICAL: served release.json does not match restored file" >&2
+    SMOKE_FAIL=1
+fi
+
+SERVED_CONTENT_SHA=$(curl -sf "${CURL_RESOLVE[@]}" "https://affpapa.org/neantik/content.json" | sha256sum | cut -d' ' -f1 || echo "missing")
+LOCAL_CONTENT_SHA=$(sha256sum "$CONTENT_JSON_LIVE" | cut -d' ' -f1)
+if [[ "$SERVED_CONTENT_SHA" != "$LOCAL_CONTENT_SHA" ]]; then
+    echo "  CRITICAL: served content.json does not match restored file" >&2
+    SMOKE_FAIL=1
+fi
+
+for fmt in dmg zip; do
+    readarray -t ARTIFACT_FIELDS < <(python3 - "$RELEASE_JSON_LIVE" "$fmt" <<'PY'
+import json
+import sys
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+artifact = next(item for item in manifest["artifacts"] if item["format"] == sys.argv[2])
+print(artifact["filename"])
+print(artifact["sha256"])
+print(artifact["sizeBytes"])
+print(artifact["url"])
+PY
+)
+    FILENAME="${ARTIFACT_FIELDS[0]}"
+    EXPECTED_SHA="${ARTIFACT_FIELDS[1]}"
+    EXPECTED_SIZE="${ARTIFACT_FIELDS[2]}"
+    DOWNLOAD_URL="${ARTIFACT_FIELDS[3]}"
+    ACTUAL_SHA=$(sha256sum "$DOWNLOADS_LIVE/$FILENAME" | cut -d' ' -f1)
+    if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
+        echo "  CRITICAL: restored $FILENAME SHA mismatch" >&2
+        SMOKE_FAIL=1
+    fi
+    RANGE_TOTAL=$(curl -sf "${CURL_RESOLVE[@]}" -I -H "Range: bytes=0-0" "$DOWNLOAD_URL" | tr -d '\r' | awk -F/ 'tolower($1) ~ /^content-range:/ {print $2}' || echo "")
+    if [[ "$RANGE_TOTAL" != "$EXPECTED_SIZE" ]]; then
+        echo "  CRITICAL: served $FILENAME size $RANGE_TOTAL != $EXPECTED_SIZE" >&2
+        SMOKE_FAIL=1
+    fi
+done
+
+if [[ "$SMOKE_FAIL" -eq 1 ]]; then
+    log_entry "ROLLBACK INCOMPLETE: v$RESTORE_VER restored but smoke failed (user=${SUDO_USER:-?})"
+    echo ""
+    echo "=== ROLLBACK INCOMPLETE: smoke gate failed ===" >&2
+    exit 1
+fi
+
+log_entry "ROLLBACK OK: restored v$RESTORE_VER from $(basename "$LATEST") (user=${SUDO_USER:-?})"
+
+echo ""
+echo "=== ROLLBACK COMPLETE: v$RESTORE_VER ==="

--- a/ops/affpapa/server/neantik-release-status
+++ b/ops/affpapa/server/neantik-release-status
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# neantik-release-status — show current NeAntik release state.
+# Root-owned, /usr/local/sbin/neantik-release-status.
+set -euo pipefail
+
+LIVE_ROOT="/var/www/hrband"
+RELEASE_JSON="$LIVE_ROOT/public/neantik/release.json"
+CONTENT_JSON="$LIVE_ROOT/public/neantik/content.json"
+BLADE="$LIVE_ROOT/resources/views/affpapa/neantik.blade.php"
+DOWNLOADS="$LIVE_ROOT/public/neantik/downloads"
+IMAGES="$LIVE_ROOT/public/img/neantik"
+STAGING="/var/www/hrband/storage/app/neantik-release-staging"
+BACKUPS="/var/www/hrband/storage/app/neantik-release-backups"
+LOG="/var/log/neantik-deploy.log"
+
+echo "=== NeAntik Release Status ==="
+echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo
+
+# Current version from release.json
+if [[ -f "$RELEASE_JSON" ]]; then
+    ver=$(python3 -c "import json,sys; d=json.load(open('$RELEASE_JSON')); print(d.get('version','?'))" 2>/dev/null || echo "?")
+    build=$(python3 -c "import json,sys; d=json.load(open('$RELEASE_JSON')); print(d.get('build','?'))" 2>/dev/null || echo "?")
+    status=$(python3 -c "import json,sys; d=json.load(open('$RELEASE_JSON')); print(d.get('status','?'))" 2>/dev/null || echo "?")
+    echo "Live version:  $ver (build $build, $status)"
+else
+    echo "Live version:  release.json NOT FOUND"
+fi
+
+# Page data is non-executable and must track the public release.
+if [[ -f "$CONTENT_JSON" ]]; then
+    content_ver=$(python3 -c "import json; print(json.load(open('$CONTENT_JSON')).get('releaseVersion','?'))" 2>/dev/null || echo "?")
+    content_updated=$(python3 -c "import json; print(json.load(open('$CONTENT_JSON')).get('updatedAt','?'))" 2>/dev/null || echo "?")
+    echo "Page content:  $content_ver (updated $content_updated)"
+else
+    echo "Page content:  content.json NOT FOUND"
+fi
+[[ -f "$BLADE" ]] && echo "Page template: root-owned Blade present" || echo "Page template: NOT FOUND"
+
+# Downloads
+echo
+echo "Downloads:"
+if [[ -d "$DOWNLOADS" ]]; then
+    # shellcheck disable=SC2010
+    ls -lhS "$DOWNLOADS" 2>/dev/null | grep -v '^total' || echo "  (empty)"
+else
+    echo "  (none)"
+fi
+
+# Images
+echo
+echo "Images:"
+if [[ -d "$IMAGES" ]]; then
+    # shellcheck disable=SC2010
+    ls -lh "$IMAGES" 2>/dev/null | grep -v '^total' || echo "  (empty)"
+else
+    echo "  (none)"
+fi
+
+# Staging
+echo
+echo "Staging:"
+if [[ -d "$STAGING" ]]; then
+    staging_count=$(find "$STAGING" -maxdepth 1 -type f 2>/dev/null | wc -l)
+    echo "  Files in staging: $staging_count"
+    if [[ "$staging_count" -gt 0 ]]; then
+        # shellcheck disable=SC2010
+        ls -lh "$STAGING" 2>/dev/null | grep -v '^total' || true
+    fi
+else
+    echo "  (not created)"
+fi
+
+# Backups
+echo
+echo "Backups:"
+if [[ -d "$BACKUPS" ]]; then
+    backup_list=$(find "$BACKUPS" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null | sort -r | head -5)
+    if [[ -n "$backup_list" ]]; then
+        echo "$backup_list" | while IFS= read -r d; do
+            echo "  $(basename "$d")"
+        done
+    else
+        echo "  (none)"
+    fi
+else
+    echo "  (none)"
+fi
+
+# Last 5 log entries
+echo
+echo "Recent log:"
+if [[ -f "$LOG" ]]; then
+    tail -5 "$LOG" || true
+else
+    echo "  (no log yet)"
+fi

--- a/ops/affpapa/server/neantik-ssh-dispatcher
+++ b/ops/affpapa/server/neantik-ssh-dispatcher
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# neantik-ssh-dispatcher — forced-command for neantik-deploy SSH.
+# /usr/local/sbin/neantik-ssh-dispatcher, owned by root.
+# Allows ONLY:
+#   neantik-release-status
+#   neantik-release-deploy [--check|--dry-run]
+#   neantik-release-abort
+#   neantik-release-rollback [--check|--dry-run]
+#   neantik-upload <strictly-validated filename>
+# Denies everything else including SFTP, scp, shell.
+set -euo pipefail
+
+CMD="${SSH_ORIGINAL_COMMAND:-}"
+
+# Filename allowlist for upload (no shell expansion — literal match)
+UPLOAD_RE='^neantik-upload (release\.json|content\.json|NeAntik-[0-9]+\.[0-9]+\.[0-9]+-arm64-notarized\.(dmg|zip|dmg\.sha256|zip\.sha256))$'
+
+case "$CMD" in
+    "neantik-release-status")
+        exec sudo /usr/local/sbin/neantik-release-status
+        ;;
+    "neantik-release-deploy")
+        exec sudo /usr/local/sbin/neantik-release-deploy
+        ;;
+    "neantik-release-deploy --check")
+        exec sudo /usr/local/sbin/neantik-release-deploy --check
+        ;;
+    "neantik-release-deploy --dry-run")
+        exec sudo /usr/local/sbin/neantik-release-deploy --dry-run
+        ;;
+    "neantik-release-abort")
+        exec sudo /usr/local/sbin/neantik-release-abort
+        ;;
+    "neantik-release-rollback")
+        exec sudo /usr/local/sbin/neantik-release-rollback
+        ;;
+    "neantik-release-rollback --check")
+        exec sudo /usr/local/sbin/neantik-release-rollback --check
+        ;;
+    "neantik-release-rollback --dry-run")
+        exec sudo /usr/local/sbin/neantik-release-rollback --dry-run
+        ;;
+    neantik-upload\ *)
+        if [[ "$CMD" =~ $UPLOAD_RE ]]; then
+            UPLOAD_FNAME="${CMD#neantik-upload }"
+            exec sudo /usr/local/sbin/neantik-upload "$UPLOAD_FNAME"
+        else
+            echo "DENIED: upload filename not allowed" >&2
+            logger -t neantik-deploy "DENIED upload: $CMD (from ${SSH_CLIENT:-unknown})"
+            exit 1
+        fi
+        ;;
+    "")
+        echo "NeAntik deploy access. Available commands:"
+        echo "  neantik-release-status"
+        echo "  neantik-release-deploy [--check|--dry-run]"
+        echo "  neantik-release-abort"
+        echo "  neantik-release-rollback [--check|--dry-run]"
+        echo "  neantik-upload <filename>"
+        exit 1
+        ;;
+    *)
+        echo "DENIED: command not allowed" >&2
+        logger -t neantik-deploy "DENIED command: $CMD (from ${SSH_CLIENT:-unknown})"
+        exit 1
+        ;;
+esac

--- a/ops/affpapa/server/neantik-upload
+++ b/ops/affpapa/server/neantik-upload
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# neantik-upload — receive a single file into staging via stdin.
+# Root-owned, called by neantik-ssh-dispatcher via sudo.
+# Usage: neantik-upload <filename>
+# Serializes the complete receive with deploy/rollback. Enforces staging quotas.
+# Blade upload is NOT allowed — template is root-owned.
+set -euo pipefail
+
+STAGING="/var/www/hrband/storage/app/neantik-release-staging"
+LOG="/var/log/neantik-deploy.log"
+LOCKFILE="/var/lock/neantik-deploy.lock"
+MAX_RELEASE_JSON=$((16 * 1024))
+MAX_CONTENT_JSON=$((64 * 1024))
+MAX_BINARY=$((300 * 1024 * 1024))
+MAX_SIDECAR=256
+MAX_STAGING_FILES=6
+MAX_STAGING_BYTES=$((650 * 1024 * 1024))
+
+log_entry() {
+    printf '%s | %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "$LOG"
+}
+
+fail() {
+    printf 'UPLOAD FAIL: %s\n' "$1" >&2
+    log_entry "UPLOAD FAIL: $1 (user=${SUDO_USER:-?})"
+    exit 1
+}
+
+# --- Argument validation ---
+[[ $# -eq 1 ]] || fail "usage: neantik-upload <filename>"
+FNAME="$1"
+
+[[ "$FNAME" =~ / ]] && fail "slash in filename"
+[[ "$FNAME" =~ \.\. ]] && fail ".. in filename"
+[[ "$FNAME" =~ [[:cntrl:]] ]] && fail "control character in filename"
+[[ "$FNAME" =~ [[:space:]] ]] && fail "whitespace in filename"
+[[ "$FNAME" =~ ^[A-Za-z0-9._-]+$ ]] || fail "unsafe characters in filename: $FNAME"
+[[ "$FNAME" =~ ^\. ]] && fail "hidden file"
+
+# Strict allowlist (NO blade)
+SEMVER_RE='^NeAntik-[0-9]+\.[0-9]+\.[0-9]+-arm64-notarized\.(dmg|zip|dmg\.sha256|zip\.sha256)$'
+case "$FNAME" in
+    release.json) MAX_SIZE=$MAX_RELEASE_JSON ;;
+    content.json) MAX_SIZE=$MAX_CONTENT_JSON ;;
+    *)
+        if [[ "$FNAME" =~ $SEMVER_RE ]]; then
+            case "$FNAME" in
+                *.dmg.sha256|*.zip.sha256) MAX_SIZE=$MAX_SIDECAR ;;
+                *.dmg|*.zip)               MAX_SIZE=$MAX_BINARY ;;
+            esac
+        else
+            fail "filename not in allowlist: $FNAME"
+        fi
+        ;;
+esac
+
+# --- Serialize uploads with deploy/rollback before receiving bytes ---
+exec 9>"$LOCKFILE"
+if ! flock -w 30 9; then
+    fail "deploy, rollback, or another upload is in progress"
+fi
+
+# --- Receive file into a hidden temporary ---
+umask 077
+TMPFILE=$(mktemp "${STAGING}/.upload-XXXXXX")
+trap 'rm -f "$TMPFILE"' EXIT
+
+LIMIT=$((MAX_SIZE + 1))
+dd bs=65536 iflag=fullblock count="$(( (LIMIT + 65535) / 65536 ))" \
+    of="$TMPFILE" 2>/dev/null || true
+
+WRITTEN=$(stat -c %s "$TMPFILE" 2>/dev/null)
+if (( WRITTEN > MAX_SIZE )); then
+    fail "file exceeds size limit ($MAX_SIZE bytes), got >= $WRITTEN"
+fi
+if (( WRITTEN == 0 )); then
+    fail "empty file"
+fi
+
+DEPLOY_UID=$(id -u neantik-deploy)
+DEPLOY_GID=$(id -g neantik-deploy)
+chown "${DEPLOY_UID}:${DEPLOY_GID}" "$TMPFILE"
+chmod 600 "$TMPFILE"
+
+# --- Staging quotas ---
+CURRENT_FILES=$(find "$STAGING" -maxdepth 1 -type f -not -name '.*' 2>/dev/null | wc -l)
+CURRENT_BYTES=$(find "$STAGING" -maxdepth 1 -type f -not -name '.*' -printf '%s\n' 2>/dev/null | awk '{ total += $1 } END { print total + 0 }')
+
+if [[ -f "$STAGING/$FNAME" ]]; then
+    OLD_SIZE=$(stat -c %s "$STAGING/$FNAME" 2>/dev/null || echo 0)
+    PROJECTED_BYTES=$(( CURRENT_BYTES - OLD_SIZE + WRITTEN ))
+else
+    PROJECTED_FILES=$((CURRENT_FILES + 1))
+    PROJECTED_BYTES=$((CURRENT_BYTES + WRITTEN))
+    if (( PROJECTED_FILES > MAX_STAGING_FILES )); then
+        fail "staging file limit reached ($MAX_STAGING_FILES files)"
+    fi
+fi
+
+if (( PROJECTED_BYTES > MAX_STAGING_BYTES )); then
+    fail "staging size limit reached (${MAX_STAGING_BYTES} bytes)"
+fi
+
+# --- Atomic rename ---
+DEST="${STAGING}/${FNAME}"
+mv -f "$TMPFILE" "$DEST"
+trap - EXIT
+
+# Release lock
+exec 9>&-
+
+log_entry "UPLOAD OK: $FNAME ($WRITTEN bytes, user=${SUDO_USER:-?})"
+printf 'OK: %s (%d bytes)\n' "$FNAME" "$WRITTEN"

--- a/ops/affpapa/server/neantik-validate-release
+++ b/ops/affpapa/server/neantik-validate-release
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for a NeAntik AffPapa release transaction."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+MAX_RELEASE_JSON_SIZE = 16 * 1024
+MAX_CONTENT_JSON_SIZE = 64 * 1024
+MAX_ARTIFACT_SIZE = 300 * 1024 * 1024
+
+REQUIRED_RELEASE_TOP = {
+    "schemaVersion",
+    "product",
+    "version",
+    "build",
+    "releaseDate",
+    "status",
+    "distribution",
+    "platform",
+    "runtime",
+    "source",
+    "artifacts",
+    "privacy",
+    "securityBaseline",
+    "limitations",
+}
+REQUIRED_CONTENT_TOP = {
+    "schemaVersion",
+    "product",
+    "releaseVersion",
+    "updatedAt",
+    "changelog",
+}
+EXPECTED_FORMATS = {"dmg", "zip"}
+ALLOWED_STATUSES = {"public-alpha", "public-beta", "stable"}
+ALLOWED_GITHUB_REPO = "https://github.com/AffPapa/neantik"
+ALLOWED_URL_PREFIX = "https://affpapa.org/neantik/downloads/"
+
+SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+DISPLAY_VERSION_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?$"
+)
+RUNTIME_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+SAFE_BASENAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+FILENAME_RE = re.compile(
+    r"^NeAntik-(?P<ver>\d+\.\d+\.\d+)-arm64-notarized\.(?P<ext>dmg|zip)$"
+)
+PLACEHOLDER_PATTERNS = {
+    "вставить",
+    "insert",
+    "placeholder",
+    "todo",
+    "fixme",
+    "changeme",
+}
+
+
+class DuplicateKeyError(ValueError):
+    pass
+
+
+def no_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DuplicateKeyError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def parse_json(path: Path, max_size: int, label: str, errors: list[str]) -> Any:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        errors.append(f"{label} is missing")
+        return None
+    if not stat.S_ISREG(metadata.st_mode):
+        errors.append(f"{label} must be a regular file")
+        return None
+    if metadata.st_size < 2 or metadata.st_size > max_size:
+        errors.append(
+            f"{label} size {metadata.st_size} is outside 2..{max_size} bytes"
+        )
+        return None
+    try:
+        raw = path.read_bytes()
+        text = raw.decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        errors.append(f"{label} cannot be read as UTF-8: {exc}")
+        return None
+    lowered = text.casefold()
+    for placeholder in PLACEHOLDER_PATTERNS:
+        if placeholder in lowered:
+            errors.append(f"{label} contains placeholder marker: {placeholder}")
+    try:
+        return json.loads(text, object_pairs_hook=no_duplicate_keys)
+    except (json.JSONDecodeError, DuplicateKeyError) as exc:
+        errors.append(f"{label} is not strict JSON: {exc}")
+        return None
+
+
+def require_string(
+    data: dict[str, Any],
+    key: str,
+    errors: list[str],
+    context: str = "",
+    max_length: int = 512,
+) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{context}{key} must be a non-empty string")
+        return ""
+    if len(value) > max_length:
+        errors.append(f"{context}{key} exceeds {max_length} characters")
+    if any(ord(char) < 32 and char not in "\t\n\r" for char in value):
+        errors.append(f"{context}{key} contains control characters")
+    return value
+
+
+def require_exact(
+    data: dict[str, Any],
+    key: str,
+    expected: Any,
+    errors: list[str],
+    context: str = "",
+) -> None:
+    if data.get(key) != expected:
+        errors.append(
+            f"{context}{key} must be {expected!r}, got {data.get(key)!r}"
+        )
+
+
+def parse_semver(value: str) -> tuple[int, int, int] | None:
+    match = SEMVER_RE.fullmatch(value)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+def validate_iso_date(value: str, label: str, errors: list[str]) -> None:
+    try:
+        dt.date.fromisoformat(value)
+    except ValueError:
+        errors.append(f"{label} must use YYYY-MM-DD, got {value!r}")
+
+
+def validate_release(
+    snapshot: Path,
+    live_json_path: Path | None,
+    errors: list[str],
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    data = parse_json(
+        snapshot / "release.json",
+        MAX_RELEASE_JSON_SIZE,
+        "release.json",
+        errors,
+    )
+    if not isinstance(data, dict):
+        errors.append("release.json root must be an object")
+        return {}, {}
+
+    missing = REQUIRED_RELEASE_TOP - set(data)
+    if missing:
+        errors.append(f"release.json missing required keys: {sorted(missing)}")
+
+    require_exact(data, "schemaVersion", 1, errors)
+    require_exact(data, "product", "NeAntik", errors)
+    require_exact(data, "distribution", "direct", errors)
+
+    version = require_string(data, "version", errors, max_length=32)
+    parsed_version = parse_semver(version)
+    if parsed_version is None:
+        errors.append(f"version is not valid semver: {version!r}")
+
+    build = data.get("build")
+    if not isinstance(build, int) or isinstance(build, bool) or build < 1:
+        errors.append(f"build must be a positive integer, got {build!r}")
+
+    status_value = require_string(data, "status", errors, max_length=32)
+    if status_value not in ALLOWED_STATUSES:
+        errors.append(
+            f"status must be one of {sorted(ALLOWED_STATUSES)}, got {status_value!r}"
+        )
+
+    release_date = require_string(data, "releaseDate", errors, max_length=10)
+    if release_date:
+        validate_iso_date(release_date, "releaseDate", errors)
+
+    platform = data.get("platform")
+    if not isinstance(platform, dict):
+        errors.append("platform must be an object")
+    else:
+        require_string(platform, "operatingSystem", errors, "platform.", 128)
+        require_exact(platform, "architecture", "arm64", errors, "platform.")
+        require_exact(
+            platform,
+            "hardware",
+            "Apple Silicon",
+            errors,
+            "platform.",
+        )
+
+    runtime = data.get("runtime")
+    runtime_version = ""
+    if not isinstance(runtime, dict):
+        errors.append("runtime must be an object")
+    else:
+        require_exact(runtime, "name", "Chromium", errors, "runtime.")
+        runtime_version = require_string(
+            runtime, "version", errors, "runtime.", 64
+        )
+        if runtime_version and not RUNTIME_VERSION_RE.fullmatch(runtime_version):
+            errors.append(
+                f"runtime.version must have four numeric components, got {runtime_version!r}"
+            )
+        require_exact(runtime, "gpu", "Metal", errors, "runtime.")
+
+    source = data.get("source")
+    if not isinstance(source, dict):
+        errors.append("source must be an object")
+    else:
+        require_exact(
+            source,
+            "repository",
+            ALLOWED_GITHUB_REPO,
+            errors,
+            "source.",
+        )
+        require_exact(source, "tag", f"v{version}", errors, "source.")
+        require_exact(
+            source,
+            "release",
+            f"{ALLOWED_GITHUB_REPO}/releases/tag/v{version}",
+            errors,
+            "source.",
+        )
+        commit = require_string(source, "commit", errors, "source.", 40)
+        if commit and not COMMIT_RE.fullmatch(commit):
+            errors.append("source.commit must be 40 lowercase hex characters")
+
+    privacy = data.get("privacy")
+    if not isinstance(privacy, dict):
+        errors.append("privacy must be an object")
+    else:
+        require_exact(privacy, "telemetry", "disabled", errors, "privacy.")
+        require_exact(privacy, "profileData", "local-only", errors, "privacy.")
+        require_exact(
+            privacy,
+            "proxyPasswords",
+            "macOS Keychain",
+            errors,
+            "privacy.",
+        )
+
+    baseline = data.get("securityBaseline")
+    if not isinstance(baseline, dict):
+        errors.append("securityBaseline must be an object")
+    else:
+        require_exact(
+            baseline,
+            "runtimeVersion",
+            runtime_version,
+            errors,
+            "securityBaseline.",
+        )
+        require_exact(
+            baseline,
+            "releaseChannel",
+            status_value,
+            errors,
+            "securityBaseline.",
+        )
+        require_string(
+            baseline,
+            "source",
+            errors,
+            "securityBaseline.",
+            128,
+        )
+
+    limitations = data.get("limitations")
+    if (
+        not isinstance(limitations, list)
+        or not limitations
+        or len(limitations) > 20
+    ):
+        errors.append("limitations must be a non-empty array with at most 20 items")
+    else:
+        for index, item in enumerate(limitations):
+            if not isinstance(item, str) or not item.strip() or len(item) > 500:
+                errors.append(
+                    f"limitations[{index}] must be a non-empty string up to 500 characters"
+                )
+
+    artifact_map: dict[str, dict[str, Any]] = {}
+    artifacts = data.get("artifacts")
+    if not isinstance(artifacts, list) or len(artifacts) != 2:
+        errors.append("artifacts must contain exactly two objects: DMG and ZIP")
+        artifacts = []
+
+    for index, artifact in enumerate(artifacts):
+        context = f"artifacts[{index}]."
+        if not isinstance(artifact, dict):
+            errors.append(f"{context[:-1]} must be an object")
+            continue
+        artifact_format = artifact.get("format")
+        if artifact_format not in EXPECTED_FORMATS:
+            errors.append(f"{context}format must be dmg or zip")
+            continue
+        if artifact_format in artifact_map:
+            errors.append(f"{context}format {artifact_format!r} is duplicated")
+            continue
+        artifact_map[artifact_format] = artifact
+
+        filename = require_string(
+            artifact, "filename", errors, context, max_length=160
+        )
+        if filename:
+            if not SAFE_BASENAME_RE.fullmatch(filename):
+                errors.append(f"{context}filename contains unsafe characters")
+            match = FILENAME_RE.fullmatch(filename)
+            if not match:
+                errors.append(f"{context}filename does not match release pattern")
+            else:
+                if match.group("ver") != version:
+                    errors.append(f"{context}filename version does not match release")
+                if match.group("ext") != artifact_format:
+                    errors.append(f"{context}filename extension does not match format")
+
+        require_exact(
+            artifact,
+            "url",
+            f"{ALLOWED_URL_PREFIX}{filename}",
+            errors,
+            context,
+        )
+        size_bytes = artifact.get("sizeBytes")
+        if (
+            not isinstance(size_bytes, int)
+            or isinstance(size_bytes, bool)
+            or size_bytes < 1
+            or size_bytes > MAX_ARTIFACT_SIZE
+        ):
+            errors.append(
+                f"{context}sizeBytes must be between 1 and {MAX_ARTIFACT_SIZE}"
+            )
+        expected_sha = artifact.get("sha256")
+        if not isinstance(expected_sha, str) or not SHA256_RE.fullmatch(
+            expected_sha
+        ):
+            errors.append(f"{context}sha256 must be 64 lowercase hex characters")
+        for signature_key in ("developerIdSigned", "notarized", "stapled"):
+            require_exact(
+                artifact,
+                signature_key,
+                True,
+                errors,
+                context,
+            )
+        require_exact(
+            artifact,
+            "gatekeeper",
+            "accepted",
+            errors,
+            context,
+        )
+
+    if set(artifact_map) != EXPECTED_FORMATS:
+        errors.append(
+            f"artifacts must contain exactly {sorted(EXPECTED_FORMATS)}"
+        )
+
+    if live_json_path and live_json_path.is_file():
+        live_errors: list[str] = []
+        live = parse_json(
+            live_json_path,
+            MAX_RELEASE_JSON_SIZE,
+            "live release.json",
+            live_errors,
+        )
+        if live_errors:
+            errors.extend(live_errors)
+        elif isinstance(live, dict):
+            live_version = parse_semver(str(live.get("version", "")))
+            live_build = live.get("build")
+            if (
+                parsed_version is not None
+                and live_version is not None
+                and parsed_version <= live_version
+            ):
+                errors.append(
+                    f"version {version} must be newer than live {live.get('version')}"
+                )
+            if (
+                isinstance(build, int)
+                and not isinstance(build, bool)
+                and isinstance(live_build, int)
+                and not isinstance(live_build, bool)
+                and build <= live_build
+            ):
+                errors.append(f"build {build} must be newer than live {live_build}")
+
+    return data, artifact_map
+
+
+def validate_content(
+    snapshot: Path,
+    release: dict[str, Any],
+    errors: list[str],
+) -> None:
+    content = parse_json(
+        snapshot / "content.json",
+        MAX_CONTENT_JSON_SIZE,
+        "content.json",
+        errors,
+    )
+    if not isinstance(content, dict):
+        errors.append("content.json root must be an object")
+        return
+
+    missing = REQUIRED_CONTENT_TOP - set(content)
+    if missing:
+        errors.append(f"content.json missing required keys: {sorted(missing)}")
+    require_exact(content, "schemaVersion", 1, errors, "content.")
+    require_exact(content, "product", "NeAntik", errors, "content.")
+    require_exact(
+        content,
+        "releaseVersion",
+        release.get("version"),
+        errors,
+        "content.",
+    )
+    updated_at = require_string(
+        content, "updatedAt", errors, "content.", max_length=10
+    )
+    if updated_at:
+        validate_iso_date(updated_at, "content.updatedAt", errors)
+
+    changelog = content.get("changelog")
+    if not isinstance(changelog, list) or not changelog or len(changelog) > 50:
+        errors.append(
+            "content.changelog must be a non-empty array with at most 50 releases"
+        )
+        return
+
+    seen_versions: set[str] = set()
+    for index, entry in enumerate(changelog):
+        context = f"content.changelog[{index}]."
+        if not isinstance(entry, dict):
+            errors.append(f"{context[:-1]} must be an object")
+            continue
+        entry_version = require_string(
+            entry, "version", errors, context, max_length=32
+        )
+        if entry_version and not DISPLAY_VERSION_RE.fullmatch(entry_version):
+            errors.append(f"{context}version has an invalid format")
+        if entry_version in seen_versions:
+            errors.append(f"{context}version {entry_version!r} is duplicated")
+        seen_versions.add(entry_version)
+
+        entry_build = entry.get("build")
+        if (
+            not isinstance(entry_build, int)
+            or isinstance(entry_build, bool)
+            or entry_build < 1
+        ):
+            errors.append(f"{context}build must be a positive integer")
+        require_string(entry, "date", errors, context, max_length=80)
+        label = entry.get("label")
+        if label is not None and (
+            not isinstance(label, str) or not label.strip() or len(label) > 80
+        ):
+            errors.append(f"{context}label must be a string up to 80 characters")
+
+        items = entry.get("items")
+        if not isinstance(items, list) or not items or len(items) > 30:
+            errors.append(f"{context}items must contain 1..30 strings")
+            continue
+        for item_index, item in enumerate(items):
+            if (
+                not isinstance(item, str)
+                or not item.strip()
+                or len(item) > 500
+            ):
+                errors.append(
+                    f"{context}items[{item_index}] must be a non-empty string up to 500 characters"
+                )
+                continue
+            if "<" in item or ">" in item:
+                errors.append(
+                    f"{context}items[{item_index}] must not contain HTML"
+                )
+
+    first = changelog[0] if changelog and isinstance(changelog[0], dict) else {}
+    if first.get("version") != release.get("version"):
+        errors.append("first changelog version must match release.version")
+    if first.get("build") != release.get("build"):
+        errors.append("first changelog build must match release.build")
+
+
+def validate_snapshot_files(
+    snapshot: Path,
+    release: dict[str, Any],
+    artifact_map: dict[str, dict[str, Any]],
+    errors: list[str],
+) -> None:
+    version = str(release.get("version", ""))
+    expected_files = {"release.json", "content.json"}
+    for extension in ("dmg", "zip", "dmg.sha256", "zip.sha256"):
+        expected_files.add(
+            f"NeAntik-{version}-arm64-notarized.{extension}"
+        )
+
+    actual_files: set[str] = set()
+    for entry in snapshot.iterdir():
+        metadata = entry.lstat()
+        if not stat.S_ISREG(metadata.st_mode):
+            errors.append(f"snapshot entry is not a regular file: {entry.name}")
+            continue
+        if entry.name.startswith("."):
+            errors.append(f"snapshot contains hidden file: {entry.name}")
+            continue
+        actual_files.add(entry.name)
+
+    missing = expected_files - actual_files
+    unexpected = actual_files - expected_files
+    if missing:
+        errors.append(f"snapshot missing required files: {sorted(missing)}")
+    if unexpected:
+        errors.append(f"snapshot contains unexpected files: {sorted(unexpected)}")
+
+    for artifact_format, artifact in artifact_map.items():
+        filename = str(artifact.get("filename", ""))
+        artifact_path = snapshot / filename
+        if not artifact_path.is_file():
+            errors.append(f"{filename}: declared artifact missing from snapshot")
+            continue
+        metadata = artifact_path.lstat()
+        if not stat.S_ISREG(metadata.st_mode):
+            errors.append(f"{filename}: artifact must be a regular file")
+            continue
+        actual_size = metadata.st_size
+        expected_size = artifact.get("sizeBytes")
+        if actual_size != expected_size:
+            errors.append(
+                f"{filename}: actual size {actual_size} != sizeBytes {expected_size}"
+            )
+
+        digest = hashlib.sha256()
+        with artifact_path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+        actual_sha = digest.hexdigest()
+        expected_sha = artifact.get("sha256")
+        if actual_sha != expected_sha:
+            errors.append(
+                f"{filename}: SHA-256 {actual_sha} != release.json {expected_sha}"
+            )
+
+        sidecar_path = snapshot / f"{filename}.sha256"
+        if not sidecar_path.is_file():
+            errors.append(f"{filename}.sha256: sidecar missing")
+            continue
+        try:
+            sidecar_parts = sidecar_path.read_text(encoding="utf-8").split()
+        except (OSError, UnicodeDecodeError) as exc:
+            errors.append(f"{filename}.sha256 cannot be read: {exc}")
+            continue
+        if not sidecar_parts:
+            errors.append(f"{filename}.sha256 is empty")
+            continue
+        if len(sidecar_parts) > 2:
+            errors.append(f"{filename}.sha256 has unexpected extra fields")
+        if sidecar_parts[0].lower() != expected_sha:
+            errors.append(f"{filename}.sha256 hash does not match release.json")
+        if len(sidecar_parts) == 2 and sidecar_parts[1].lstrip("*") != filename:
+            errors.append(f"{filename}.sha256 filename does not match artifact")
+
+
+def validate(snapshot_dir: str, live_json: str | None) -> list[str]:
+    errors: list[str] = []
+    snapshot = Path(snapshot_dir)
+    if not snapshot.is_dir():
+        return ["snapshot path must be a directory"]
+
+    release, artifacts = validate_release(
+        snapshot,
+        Path(live_json) if live_json else None,
+        errors,
+    )
+    if release:
+        validate_content(snapshot, release, errors)
+        validate_snapshot_files(snapshot, release, artifacts, errors)
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) not in {2, 3}:
+        print(
+            f"Usage: {sys.argv[0]} <snapshot_dir> [live_release.json]",
+            file=sys.stderr,
+        )
+        return 2
+    errors = validate(sys.argv[1], sys.argv[2] if len(sys.argv) == 3 else None)
+    if errors:
+        for error in errors:
+            print(f"VALIDATION ERROR: {error}", file=sys.stderr)
+        return 1
+    print("VALIDATION OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/affpapa/tests/test_validate_release.py
+++ b/ops/affpapa/tests/test_validate_release.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Regression tests for the restricted AffPapa release snapshot contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+VALIDATOR = ROOT / "ops/affpapa/server/neantik-validate-release"
+VERSION = "0.3.15"
+DMG = f"NeAntik-{VERSION}-arm64-notarized.dmg"
+ZIP = f"NeAntik-{VERSION}-arm64-notarized.zip"
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+class ReleaseValidatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(
+            prefix="neantik-affpapa-validator-"
+        )
+        self.snapshot = Path(self.temporary.name)
+        self.dmg_bytes = b"dmg\n"
+        self.zip_bytes = b"zip\n"
+        self.release = {
+            "schemaVersion": 1,
+            "product": "NeAntik",
+            "version": VERSION,
+            "build": 18,
+            "releaseDate": "2026-08-04",
+            "status": "public-alpha",
+            "distribution": "direct",
+            "platform": {
+                "operatingSystem": "macOS 14 or later",
+                "architecture": "arm64",
+                "hardware": "Apple Silicon",
+            },
+            "runtime": {
+                "name": "Chromium",
+                "version": "150.0.7871.186",
+                "gpu": "Metal",
+            },
+            "source": {
+                "repository": "https://github.com/AffPapa/neantik",
+                "tag": f"v{VERSION}",
+                "commit": "73b74f8b8ba7e66cc3ea2b5b88dcd52c7b3dc5f8",
+                "release": (
+                    "https://github.com/AffPapa/neantik/releases/tag/"
+                    f"v{VERSION}"
+                ),
+            },
+            "artifacts": [
+                {
+                    "format": "dmg",
+                    "filename": DMG,
+                    "url": f"https://affpapa.org/neantik/downloads/{DMG}",
+                    "sizeBytes": len(self.dmg_bytes),
+                    "sha256": digest(self.dmg_bytes),
+                    "developerIdSigned": True,
+                    "notarized": True,
+                    "stapled": True,
+                    "gatekeeper": "accepted",
+                },
+                {
+                    "format": "zip",
+                    "filename": ZIP,
+                    "url": f"https://affpapa.org/neantik/downloads/{ZIP}",
+                    "sizeBytes": len(self.zip_bytes),
+                    "sha256": digest(self.zip_bytes),
+                    "developerIdSigned": True,
+                    "notarized": True,
+                    "stapled": True,
+                    "gatekeeper": "accepted",
+                },
+            ],
+            "privacy": {
+                "telemetry": "disabled",
+                "profileData": "local-only",
+                "proxyPasswords": "macOS Keychain",
+            },
+            "securityBaseline": {
+                "runtimeVersion": "150.0.7871.186",
+                "source": "Chrome Releases",
+                "releaseChannel": "public-alpha",
+            },
+            "limitations": ["Public-alpha regression fixture."],
+        }
+        self.content = {
+            "schemaVersion": 1,
+            "product": "NeAntik",
+            "releaseVersion": VERSION,
+            "updatedAt": "2026-08-04",
+            "changelog": [
+                {
+                    "version": VERSION,
+                    "build": 18,
+                    "date": "4 августа 2026",
+                    "label": "Public Alpha",
+                    "items": ["Проверка канонического release gate"],
+                }
+            ],
+        }
+        self.write_snapshot()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_snapshot(self) -> None:
+        (self.snapshot / DMG).write_bytes(self.dmg_bytes)
+        (self.snapshot / ZIP).write_bytes(self.zip_bytes)
+        for filename, data in (
+            (DMG, self.dmg_bytes),
+            (ZIP, self.zip_bytes),
+        ):
+            (self.snapshot / f"{filename}.sha256").write_text(
+                f"{digest(data)}  {filename}\n",
+                encoding="utf-8",
+            )
+        (self.snapshot / "release.json").write_text(
+            json.dumps(self.release, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        (self.snapshot / "content.json").write_text(
+            json.dumps(self.content, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def validate(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(VALIDATOR), str(self.snapshot)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def assert_rejected(self, expected: str) -> None:
+        result = self.validate()
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn(expected, result.stderr)
+
+    def test_accepts_exact_canonical_snapshot(self) -> None:
+        result = self.validate()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "VALIDATION OK")
+
+    def test_rejects_missing_artifact(self) -> None:
+        (self.snapshot / ZIP).unlink()
+        self.assert_rejected("snapshot missing required files")
+
+    def test_rejects_missing_sidecar(self) -> None:
+        (self.snapshot / f"{ZIP}.sha256").unlink()
+        self.assert_rejected("snapshot missing required files")
+
+    def test_rejects_corrupt_artifact(self) -> None:
+        (self.snapshot / ZIP).write_bytes(b"changed")
+        self.assert_rejected("actual size")
+
+    def test_rejects_wrong_sha(self) -> None:
+        self.release["artifacts"][1]["sha256"] = "0" * 64
+        self.write_snapshot()
+        self.assert_rejected("release.json")
+
+    def test_rejects_wrong_repository(self) -> None:
+        self.release["source"]["repository"] = (
+            "https://github.com/example/neantik"
+        )
+        self.write_snapshot()
+        self.assert_rejected("source.repository")
+
+    def test_rejects_content_version_mismatch(self) -> None:
+        self.content["releaseVersion"] = "0.3.99"
+        self.write_snapshot()
+        self.assert_rejected("content.releaseVersion")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/neantik-affpapa-release
+++ b/scripts/neantik-affpapa-release
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# One least-privilege AffPapa release client for local Claude and Codex.
+set -euo pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+WORKSPACE_ROOT=$(cd "$PROJECT_ROOT/.." && pwd)
+KEY="$WORKSPACE_ROOT/.secrets/ssh/neantik_affpapa_ed25519"
+KNOWN_HOSTS="$WORKSPACE_ROOT/.secrets/ssh/neantik_affpapa_known_hosts"
+VALIDATOR="$PROJECT_ROOT/ops/affpapa/server/neantik-validate-release"
+HOST="neantik-deploy@167.233.230.87"
+EXPECTED_KEY_FP="SHA256:VM+qNg4wh4bdPfBMN+0vUyeXvazmPdrlT84SfAhLs18"
+EXPECTED_HOST_FP="SHA256:Q/dEY6G+KRaAk1sDgOAaaVxLZxIrQZElszGwVyn5OU8"
+
+SSH_OPTIONS=(
+    -i "$KEY"
+    -o BatchMode=yes
+    -o IdentitiesOnly=yes
+    -o StrictHostKeyChecking=yes
+    -o UserKnownHostsFile="$KNOWN_HOSTS"
+    -o ControlMaster=no
+    -o ControlPath=none
+    -o ControlPersist=no
+    -o ConnectTimeout=20
+)
+
+usage() {
+    cat <<'EOF'
+NeAntik AffPapa Direct release client
+
+Команды:
+  doctor                   одной командой проверить доступ и live-релиз
+  status                   показать live/staging/backups
+  check                    проверить уже загруженный staging без публикации
+  dry-run                  полный no-change preflight staging
+  abort                    безопасно очистить только NeAntik staging
+  prepare <release-dir>    проверить и загрузить кандидат, затем server check
+  publish <release-dir>    prepare + deploy + live verification
+  upload <file>            загрузить один разрешённый файл
+  rollback-check           проверить доступность отката без изменений
+  rollback                 откатить последний NeAntik release backup
+  verify-live              проверить текущие HTML/JSON/DMG/ZIP headers
+
+release-dir должен содержать:
+  release.json
+  content.json
+  NeAntik-<version>-arm64-notarized.dmg
+  NeAntik-<version>-arm64-notarized.dmg.sha256
+  NeAntik-<version>-arm64-notarized.zip
+  NeAntik-<version>-arm64-notarized.zip.sha256
+EOF
+}
+
+fail() {
+    echo "Ошибка: $*" >&2
+    exit 1
+}
+
+preflight_access() {
+    [[ -f "$KEY" ]] || fail "не найден deploy key: $KEY"
+    [[ -f "$KNOWN_HOSTS" ]] || fail "не найден pinned known_hosts: $KNOWN_HOSTS"
+    [[ -x "$VALIDATOR" ]] || fail "не найден validator: $VALIDATOR"
+    local key_fp host_fp
+    local key_mode known_hosts_mode
+    key_fp=$(ssh-keygen -lf "$KEY" | awk '{print $2}')
+    host_fp=$(ssh-keygen -lf "$KNOWN_HOSTS" | awk '{print $2}')
+    key_mode=$(stat -f '%Lp' "$KEY")
+    known_hosts_mode=$(stat -f '%Lp' "$KNOWN_HOSTS")
+    [[ "$key_fp" == "$EXPECTED_KEY_FP" ]] || fail "неверный deploy key fingerprint"
+    [[ "$host_fp" == "$EXPECTED_HOST_FP" ]] || fail "неверный host-key fingerprint"
+    [[ "$key_mode" == "600" ]] || fail "deploy key должен иметь права 0600"
+    [[ "$known_hosts_mode" == "600" ]] ||
+        fail "pinned known_hosts должен иметь права 0600"
+}
+
+remote() {
+    # Arguments are selected from the exact command allowlist below.
+    # shellcheck disable=SC2029
+    ssh "${SSH_OPTIONS[@]}" "$HOST" "$@"
+}
+
+upload_file() {
+    local path="$1"
+    [[ -f "$path" ]] || fail "файл не найден: $path"
+    [[ -s "$path" ]] || fail "пустой файл: $path"
+    local name
+    name=$(basename "$path")
+    remote "neantik-upload $name" <"$path"
+}
+
+release_files() {
+    python3 - "$1/release.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).parent
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(root / "release.json")
+print(root / "content.json")
+for artifact in sorted(manifest["artifacts"], key=lambda item: item["format"]):
+    path = root / artifact["filename"]
+    print(path)
+    print(Path(str(path) + ".sha256"))
+PY
+}
+
+verify_local_artifacts() {
+    local directory="$1"
+    local dmg zip
+    dmg=$(python3 - "$directory/release.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+root = Path(sys.argv[1]).parent
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(root / next(item["filename"] for item in manifest["artifacts"] if item["format"] == "dmg"))
+PY
+)
+    zip=$(python3 - "$directory/release.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+root = Path(sys.argv[1]).parent
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(root / next(item["filename"] for item in manifest["artifacts"] if item["format"] == "zip"))
+PY
+)
+    "$PROJECT_ROOT/scripts/verify-direct-notarized-dmg.sh" "$dmg"
+    python3 "$PROJECT_ROOT/scripts/verify-direct-notarized-archive.py" \
+        --project-root "$PROJECT_ROOT" \
+        --archive "$zip"
+}
+
+prepare_release() {
+    local directory="$1"
+    [[ -d "$directory" ]] || fail "каталог кандидата не найден: $directory"
+    directory=$(cd "$directory" && pwd)
+    local live_manifest
+    live_manifest=$(mktemp /tmp/neantik-live-release.XXXXXX.json)
+    curl -fsS --max-time 30 \
+        https://affpapa.org/neantik/release.json \
+        -o "$live_manifest"
+    if ! python3 "$VALIDATOR" "$directory" "$live_manifest"; then
+        rm -f "$live_manifest"
+        return 1
+    fi
+    rm -f "$live_manifest"
+    verify_local_artifacts "$directory"
+
+    remote neantik-release-abort
+    local uploaded=0
+    while IFS= read -r file; do
+        if ! upload_file "$file"; then
+            remote neantik-release-abort || true
+            return 1
+        fi
+        uploaded=$((uploaded + 1))
+    done < <(release_files "$directory")
+    [[ "$uploaded" -eq 6 ]] || {
+        remote neantik-release-abort || true
+        fail "ожидалось 6 release-файлов, загружено $uploaded"
+    }
+    if ! remote "neantik-release-deploy --check"; then
+        remote neantik-release-abort || true
+        return 1
+    fi
+    echo "PASS: кандидат проверен и оставлен в staging."
+}
+
+verify_live() {
+    local release_json content_json
+    release_json=$(mktemp /tmp/neantik-live-release.XXXXXX.json)
+    content_json=$(mktemp /tmp/neantik-live-content.XXXXXX.json)
+    curl -fsS --max-time 30 https://affpapa.org/neantik -o /dev/null
+    curl -fsS --max-time 30 https://affpapa.org/neantik/release.json -o "$release_json"
+    curl -fsS --max-time 30 https://affpapa.org/neantik/content.json -o "$content_json"
+    python3 - "$release_json" "$content_json" <<'PY'
+import json
+import sys
+
+release = json.load(open(sys.argv[1], encoding="utf-8"))
+content = json.load(open(sys.argv[2], encoding="utf-8"))
+assert release["version"] == content["releaseVersion"]
+assert release["build"] == content["changelog"][0]["build"]
+assert release["version"] == content["changelog"][0]["version"]
+print(f"PASS: live {release['version']} (build {release['build']})")
+for artifact in release["artifacts"]:
+    print(artifact["format"], artifact["url"], artifact["sizeBytes"], artifact["sha256"])
+PY
+    while IFS=$'\t' read -r url expected_size; do
+        local total
+        total=$(curl -fsSI --max-time 30 -H "Range: bytes=0-0" "$url" |
+            tr -d '\r' |
+            awk -F/ 'tolower($1) ~ /^content-range:/ {print $2}')
+        [[ "$total" == "$expected_size" ]] ||
+            fail "Content-Range $total не совпадает с $expected_size для $url"
+    done < <(python3 - "$release_json" <<'PY'
+import json
+import sys
+for artifact in json.load(open(sys.argv[1], encoding="utf-8"))["artifacts"]:
+    print(f"{artifact['url']}\t{artifact['sizeBytes']}")
+PY
+)
+    rm -f "$release_json" "$content_json"
+    echo "PASS: landing, release.json, content.json, DMG и ZIP доступны."
+}
+
+doctor() {
+    echo "NeAntik AffPapa deploy doctor"
+    echo "PASS: локальный ключ и host key закреплены по fingerprint."
+    remote neantik-release-status
+    if remote "uname -a" >/dev/null 2>&1; then
+        fail "restricted SSH неожиданно разрешил произвольную команду"
+    fi
+    echo "PASS: shell и произвольные SSH-команды запрещены."
+    verify_live
+    echo "PASS: Claude/Codex могут работать через единый restricted release client."
+}
+
+main() {
+    preflight_access
+    local command="${1:-}"
+    case "$command" in
+        doctor)
+            [[ $# -eq 1 ]] || fail "doctor не принимает аргументы"
+            doctor
+            ;;
+        status)
+            [[ $# -eq 1 ]] || fail "status не принимает аргументы"
+            remote neantik-release-status
+            ;;
+        check)
+            [[ $# -eq 1 ]] || fail "check не принимает аргументы"
+            remote "neantik-release-deploy --check"
+            ;;
+        dry-run)
+            [[ $# -eq 1 ]] || fail "dry-run не принимает аргументы"
+            remote "neantik-release-deploy --dry-run"
+            ;;
+        abort)
+            [[ $# -eq 1 ]] || fail "abort не принимает аргументы"
+            remote neantik-release-abort
+            ;;
+        prepare)
+            [[ $# -eq 2 ]] || fail "использование: prepare <release-dir>"
+            prepare_release "$2"
+            ;;
+        publish)
+            [[ $# -eq 2 ]] || fail "использование: publish <release-dir>"
+            prepare_release "$2"
+            if ! remote neantik-release-deploy; then
+                remote neantik-release-abort || true
+                return 1
+            fi
+            verify_live
+            ;;
+        upload)
+            [[ $# -eq 2 ]] || fail "использование: upload <file>"
+            upload_file "$2"
+            ;;
+        rollback-check)
+            [[ $# -eq 1 ]] || fail "rollback-check не принимает аргументы"
+            remote "neantik-release-rollback --check"
+            ;;
+        rollback)
+            [[ $# -eq 1 ]] || fail "rollback не принимает аргументы"
+            remote neantik-release-rollback
+            verify_live
+            ;;
+        verify-live)
+            [[ $# -eq 1 ]] || fail "verify-live не принимает аргументы"
+            verify_live
+            ;;
+        -h|--help|help|"")
+            usage
+            ;;
+        *)
+            usage >&2
+            fail "неизвестная команда: $command"
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Что изменено

- добавлен единый клиент `scripts/neantik-affpapa-release` для Codex и Claude;
- добавлена команда `doctor` для проверки ключа, pinned host key, restricted SSH и live-релиза;
- добавлен fail-closed серверный release gate с атомарным deploy/rollback, staging lock и строгим allowlist;
- Blade-шаблон сделан root-owned и читает неисполняемые `release.json` и `content.json`;
- добавлены инструкции `AGENTS.md` и `CLAUDE.md`;
- добавлены 7 регрессионных тестов canonical release snapshot.

## Зачем

Предыдущий процесс смешивал ручные SSH-команды, разные схемы manifest и
изменяемый шаблон страницы. Новый путь оставляет одну команду публикации, не
выдаёт shell/SFTP и не позволяет release-ключу загружать PHP/Blade.

## Проверки

- `bash -n` и ShellCheck для всех shell-скриптов;
- 7/7 тестов validator;
- clean exported open-source tree gate;
- `neantik-affpapa-release doctor`;
- restricted SSH negative tests;
- live desktop/mobile QA без overflow и console errors;
- полный публичный SHA-256 DMG и ZIP;
- GitHub Release и CPA.TG redirects проверены.

Live 0.3.14 (17) и существующие бинарники не изменялись.
