### PR TITLE
Fix Direct release bytecode cache cleanup

### DIFF
--- a/scripts/notarize-direct-candidate.sh
+++ b/scripts/notarize-direct-candidate.sh
@@ -19,9 +19,18 @@ case "${NEANTIK_RELEASE_CHANNEL:-}" in
     ;;
 esac
 
-find "$PROJECT_DIR/scripts" \
-  \( -name __pycache__ -type d -prune -exec rm -rf {} + \) -o \
-  \( -name '*.pyc' -type f -delete \)
+# The source receipt rejects executable bytecode beside any tracked Python
+# source. Tests may create these caches outside scripts/, so derive the exact
+# cleanup scope from Git instead of maintaining a fragile hard-coded list.
+git -C "$PROJECT_DIR" ls-files -z -- '*.py' |
+  while IFS= read -r -d '' tracked_python; do
+    python_parent="$PROJECT_DIR/$(dirname "$tracked_python")"
+    python_cache="$python_parent/__pycache__"
+    if [[ -d "$python_cache" ]]; then
+      find "$python_cache" -depth -delete
+    fi
+    find "$python_parent" -maxdepth 1 -type f -name '*.pyc' -delete
+  done
 
 RELEASE_PYTHON="/opt/homebrew/bin/python3"
 if [[ ! -x "$RELEASE_PYTHON" ]] ||

--- a/scripts/tests/test_release_direct_script.py
+++ b/scripts/tests/test_release_direct_script.py
@@ -146,6 +146,10 @@ class ReleaseDirectScriptTests(unittest.TestCase):
         self.assertNotIn("stapler", wrapper)
         self.assertIn("notarize_direct_transaction.py", wrapper)
         self.assertIn("run-isolated-release-python.py", wrapper)
+        self.assertIn("git -C \"$PROJECT_DIR\" ls-files -z -- '*.py'", wrapper)
+        self.assertIn('python_cache="$python_parent/__pycache__"', wrapper)
+        self.assertIn('find "$python_cache" -depth -delete', wrapper)
+        self.assertNotIn('find "$PROJECT_DIR/scripts"', wrapper)
         self.assertIn("/opt/homebrew/bin/python3", wrapper)
         self.assertIn("Python 3.11", wrapper)
         self.assertLess(


### PR DESCRIPTION
## Что изменено

- release wrapper теперь очищает `__pycache__` и `.pyc` рядом со всеми отслеживаемыми Python-файлами, а не только внутри `scripts/`;
- область очистки выводится из `git ls-files`, поэтому новые release/ops каталоги автоматически покрываются;
- добавлена регрессионная проверка контракта wrapper.

## Причина

Direct notarization 0.3.15 был безопасно остановлен source-receipt gate из-за `ops/affpapa/tests/__pycache__`. Старый hard-coded cleanup не охватывал этот каталог.

## Проверки

- `zsh -n scripts/notarize-direct-candidate.sh`
- `python3 -I -B scripts/tests/test_release_direct_script.py`
- `python3 -I -B -m unittest discover -s scripts/tests -p 'test_*.py'`
- 476 тестов PASS, 1 штатно пропущен
- `git diff --check`

Кандидат приложения и подтверждённый GUI A → B → A evidence не изменяются.
