### PR TITLE
Recover stale notarization submit intents safely

### DIFF
--- a/scripts/notarize_direct_transaction.py
+++ b/scripts/notarize_direct_transaction.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import hashlib
 import json
 import os
 import plistlib
@@ -297,11 +298,11 @@ def parse_notary_submission(output: str) -> str:
     return identifier
 
 
-def find_notary_submission_in_history(
+def find_notary_submission_in_history_or_none(
     output: str,
     *,
     submission_name: str,
-) -> str:
+) -> tuple[str | None, str]:
     try:
         payload = json.loads(
             output,
@@ -340,6 +341,18 @@ def find_notary_submission_in_history(
         return None
 
     found = walk(payload)
+    return found, hashlib.sha256(output.encode("utf-8")).hexdigest()
+
+
+def find_notary_submission_in_history(
+    output: str,
+    *,
+    submission_name: str,
+) -> str:
+    found, _history_sha256 = find_notary_submission_in_history_or_none(
+        output,
+        submission_name=submission_name,
+    )
     if found is None:
         raise DirectNotaryTransactionError(
             "Apple submission effect is unknown and notary history does "
@@ -1255,6 +1268,221 @@ def _receipt_data(
     return matching[0]
 
 
+def _transaction_matches_current_release(
+    receipts: tuple[STATE.StateReceipt, ...],
+    *,
+    archive_name: str,
+    inputs: CandidateInputs,
+    release_source: SOURCE.ReleaseSourceSnapshot,
+    runtime_build_evidence: dict[str, object],
+    release_channel: str,
+) -> bool:
+    created = _receipt_data(receipts, "transaction-created")
+    return (
+        created.get("archiveName") == archive_name
+        and created.get("releaseChannel") == release_channel
+        and created.get("candidateInputs")
+        == {
+            "infoPlist": inputs.info.sha256,
+            "manifest": inputs.manifest.sha256,
+            "evidence": inputs.evidence.sha256,
+            "attestation": inputs.attestation.sha256,
+        }
+        and created.get("releaseSource") == release_source.payload
+        and created.get("runtimeBuildEvidence")
+        == runtime_build_evidence
+    )
+
+
+def _validate_reconciliation_marker(
+    marker: Path,
+    *,
+    transaction_id: str,
+    archive_name: str,
+    submission_name: str,
+) -> None:
+    try:
+        raw = _read_private_regular_file(
+            marker,
+            maximum_bytes=16 * 1024,
+        )
+        payload = json.loads(
+            raw,
+            object_pairs_hook=_reject_duplicate_json_pairs,
+        )
+    except (json.JSONDecodeError, TypeError) as error:
+        raise DirectNotaryTransactionError(
+            "notary reconciliation marker is invalid"
+        ) from error
+    if (
+        not isinstance(payload, dict)
+        or _canonical_private_json(payload) != raw
+        or set(payload)
+        != {
+            "archiveName",
+            "checkedAtUnixNs",
+            "historySHA256",
+            "markerType",
+            "result",
+            "schemaVersion",
+            "submissionNameSHA256",
+            "transactionId",
+        }
+        or payload.get("schemaVersion") != 1
+        or payload.get("markerType")
+        != "neantik-notary-reconciliation"
+        or payload.get("result") != "submission-absent"
+        or payload.get("transactionId") != transaction_id
+        or payload.get("archiveName") != archive_name
+        or not isinstance(payload.get("checkedAtUnixNs"), int)
+        or isinstance(payload.get("checkedAtUnixNs"), bool)
+        or int(payload["checkedAtUnixNs"]) <= 0
+        or not isinstance(payload.get("historySHA256"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", payload["historySHA256"])
+        is None
+        or payload.get("submissionNameSHA256")
+        != hashlib.sha256(submission_name.encode("utf-8")).hexdigest()
+    ):
+        raise DirectNotaryTransactionError(
+            "notary reconciliation marker is invalid"
+        )
+
+
+def reconcile_mismatched_submit_intent(
+    active: tuple[Path, tuple[STATE.StateReceipt, ...]],
+    *,
+    project_root: Path,
+    notary_profile: str,
+    runner: CommandRunner,
+) -> bool:
+    """Prove a stale submit intent had no Apple effect, then retain it.
+
+    The durable submit-intent receipt is written before invoking Apple. If the
+    invocation fails before returning an id, a later clean source commit must
+    not silently reuse that candidate. A strict history query is the only
+    automatic no-effect proof: a matching name remains blocking, while an
+    absent name is recorded inside the exact transaction before inode-verified
+    retirement.
+    """
+    transaction_root, receipts = active
+    if receipts[-1].stage != "submit-intent":
+        return False
+    created = _receipt_data(receipts, "transaction-created")
+    submission_name = created.get("submissionName")
+    archive_name = created.get("archiveName")
+    transaction_id = receipts[0].payload.get("transactionId")
+    if (
+        not isinstance(submission_name, str)
+        or not isinstance(archive_name, str)
+        or not isinstance(transaction_id, str)
+    ):
+        raise DirectNotaryTransactionError(
+            "stale submit-intent transaction identity is invalid"
+        )
+    history_output = run_checked(
+        [
+            "xcrun",
+            "notarytool",
+            "history",
+            "--keychain-profile",
+            notary_profile,
+            "--output-format",
+            "json",
+        ],
+        cwd=project_root,
+        runner=runner,
+        label="stale Apple notarization history reconciliation",
+    )
+    found, history_sha256 = find_notary_submission_in_history_or_none(
+        history_output,
+        submission_name=submission_name,
+    )
+    if found is not None:
+        raise DirectNotaryTransactionError(
+            "stale transaction has a matching Apple submission and "
+            "requires exact-source recovery"
+        )
+
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        directory_flags |= os.O_NOFOLLOW
+    descriptor = -1
+    try:
+        descriptor = os.open(transaction_root, directory_flags)
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISDIR(before.st_mode)
+            or before.st_uid != os.geteuid()
+            or stat.S_IMODE(before.st_mode) != 0o700
+        ):
+            raise DirectNotaryTransactionError(
+                "stale submit-intent transaction directory is unsafe"
+        )
+        marker = transaction_root / "notary-reconciliation.json"
+        if os.path.lexists(marker):
+            _validate_reconciliation_marker(
+                marker,
+                transaction_id=transaction_id,
+                archive_name=archive_name,
+                submission_name=submission_name,
+            )
+        else:
+            write_private_json(
+                marker,
+                {
+                    "archiveName": archive_name,
+                    "checkedAtUnixNs": time.time_ns(),
+                    "historySHA256": history_sha256,
+                    "markerType": "neantik-notary-reconciliation",
+                    "result": "submission-absent",
+                    "schemaVersion": 1,
+                    "submissionNameSHA256": hashlib.sha256(
+                        submission_name.encode("utf-8")
+                    ).hexdigest(),
+                    "transactionId": transaction_id,
+                },
+            )
+            _validate_reconciliation_marker(
+                marker,
+                transaction_id=transaction_id,
+                archive_name=archive_name,
+                submission_name=submission_name,
+            )
+        after = os.fstat(descriptor)
+        if (
+            before.st_dev != after.st_dev
+            or before.st_ino != after.st_ino
+            or before.st_uid != after.st_uid
+            or before.st_mode != after.st_mode
+        ):
+            raise DirectNotaryTransactionError(
+                "stale submit-intent transaction changed during "
+                "reconciliation"
+            )
+        retirement = retire_exact_transaction(
+            transaction_root,
+            descriptor=descriptor,
+            expected_device=before.st_dev,
+            expected_inode=before.st_ino,
+        )
+        if not (
+            retirement.moved
+            and retirement.durable
+            and retirement.verified
+        ):
+            raise DirectNotaryTransactionError(
+                "reconciled stale transaction could not be safely retired"
+            )
+        return True
+    except OSError as error:
+        raise DirectNotaryTransactionError(
+            "stale submit-intent transaction could not be reconciled"
+        ) from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
 def observe_public_release_pair(
     archive: TRANSACTION.FileSeal,
     checksum: TRANSACTION.FileSeal,
@@ -1300,18 +1528,13 @@ def resume_known_transaction(
             "operator cleanup"
         )
     created = _receipt_data(receipts, "transaction-created")
-    expected_inputs = {
-        "infoPlist": inputs.info.sha256,
-        "manifest": inputs.manifest.sha256,
-        "evidence": inputs.evidence.sha256,
-        "attestation": inputs.attestation.sha256,
-    }
-    if (
-        created.get("archiveName") != archive_name
-        or created.get("releaseChannel") != release_channel
-        or created.get("candidateInputs") != expected_inputs
-        or created.get("releaseSource") != release_source.payload
-        or created.get("runtimeBuildEvidence") != runtime_build_evidence
+    if not _transaction_matches_current_release(
+        receipts,
+        archive_name=archive_name,
+        inputs=inputs,
+        release_source=release_source,
+        runtime_build_evidence=runtime_build_evidence,
+        release_channel=release_channel,
     ):
         raise DirectNotaryTransactionError(
             "unfinished transaction does not match the exact current "
@@ -2003,6 +2226,24 @@ def run_transaction(
             archive_name,
             exclude=transaction_root,
         )
+        if active is not None:
+            if (
+                not _transaction_matches_current_release(
+                    active[1],
+                    archive_name=archive_name,
+                    inputs=inputs,
+                    release_source=release_source,
+                    runtime_build_evidence=bound_runtime_build_evidence,
+                    release_channel=release_channel,
+                )
+                and reconcile_mismatched_submit_intent(
+                    active,
+                    project_root=project_root,
+                    notary_profile=notary_profile,
+                    runner=runner,
+                )
+            ):
+                active = None
         if active is not None:
             resumed = resume_known_transaction(
                 active,

--- a/scripts/notary_transaction_inspector.py
+++ b/scripts/notary_transaction_inspector.py
@@ -37,7 +37,8 @@ _STATE_TEMPORARY_NAME = re.compile(
     r"\.tmp-[0-9a-f]{32}$"
 )
 _ROOT_TEMPORARY_NAME = re.compile(
-    r"^\.(?:init-marker|apple-accepted|notary-receipt)\.json"
+    r"^\.(?:init-marker|apple-accepted|notary-receipt|"
+    r"notary-reconciliation)\.json"
     r"\.tmp-[0-9a-f]{32}$"
 )
 _STAGES: tuple[tuple[str, str], ...] = (
@@ -64,6 +65,7 @@ _ALLOWED_ROOT_ENTRIES = frozenset(
         "final-check",
         "inputs",
         "notary-receipt.json",
+        "notary-reconciliation.json",
         "precheck",
         "state",
         "submitted",
@@ -959,6 +961,61 @@ def _read_marker(
     return payload
 
 
+def _read_reconciliation_marker(
+    root: int,
+    *,
+    expected_device: int,
+    transaction_id: str,
+    state_context: dict[str, object],
+) -> dict[str, object]:
+    payload = _decode_canonical_json(
+        _read_regular_file_at(
+            root,
+            "notary-reconciliation.json",
+            expected_device=expected_device,
+            expected_mode=0o400,
+            maximum_bytes=_MAXIMUM_MARKER_BYTES,
+        )
+    )
+    if set(payload) != {
+        "archiveName",
+        "checkedAtUnixNs",
+        "historySHA256",
+        "markerType",
+        "result",
+        "schemaVersion",
+        "submissionNameSHA256",
+        "transactionId",
+    }:
+        raise NotaryTransactionInspectionError(
+            "invalid-reconciliation-schema"
+        )
+    checked_at = payload.get("checkedAtUnixNs")
+    submission_name = state_context.get("submission")
+    if (
+        payload.get("schemaVersion") != 1
+        or payload.get("markerType")
+        != "neantik-notary-reconciliation"
+        or payload.get("result") != "submission-absent"
+        or payload.get("transactionId") != transaction_id
+        or payload.get("archiveName") != state_context.get("archive")
+        or not isinstance(checked_at, int)
+        or isinstance(checked_at, bool)
+        or checked_at <= 0
+        or not isinstance(submission_name, str)
+        or payload.get("submissionNameSHA256")
+        != hashlib.sha256(submission_name.encode("utf-8")).hexdigest()
+    ):
+        raise NotaryTransactionInspectionError(
+            "invalid-reconciliation-schema"
+        )
+    _require_sha(
+        payload.get("historySHA256"),
+        code="invalid-reconciliation-schema",
+    )
+    return payload
+
+
 def _exclusive_lock_is_live(
     parent: int,
     name: str,
@@ -1451,6 +1508,7 @@ def _classify_transaction(
     archive_name: str | None,
     expected_archive_name: str | None,
     live_lease: bool | None,
+    reconciliation: dict[str, object] | None,
 ) -> InspectionRecord:
     marker_id = (
         str(marker["transactionId"]) if marker is not None else None
@@ -1465,6 +1523,10 @@ def _classify_transaction(
             "marker-state-id-mismatch"
         )
     if category == "initialization":
+        if reconciliation is not None:
+            raise NotaryTransactionInspectionError(
+                "initialization-has-reconciliation"
+            )
         match = _INITIAL_NAME.fullmatch(name)
         if match is None:
             raise NotaryTransactionInspectionError(
@@ -1507,6 +1569,23 @@ def _classify_transaction(
         if stage is None:
             raise NotaryTransactionInspectionError(
                 "active-state-missing"
+            )
+        if reconciliation is not None:
+            if stage != "submit-intent":
+                raise NotaryTransactionInspectionError(
+                    "reconciliation-stage-mismatch"
+                )
+            return _record(
+                category=category,
+                name=name,
+                status="active-reconciled-retirement-pending",
+                stage=stage,
+                external_effect="none",
+                structurally_safe=True,
+                release_blocking=True,
+                operator_action=True,
+                live_lease=None,
+                reason_code="apple-history-proves-submission-absent",
             )
         if (
             expected_archive_name is None
@@ -1573,6 +1652,23 @@ def _classify_transaction(
     if retired_match is None:
         raise NotaryTransactionInspectionError(
             "invalid-retired-name"
+        )
+    if reconciliation is not None:
+        if stage != "submit-intent":
+            raise NotaryTransactionInspectionError(
+                "reconciliation-stage-mismatch"
+            )
+        return _record(
+            category=category,
+            name=name,
+            status="retired-reconciled-no-effect",
+            stage=stage,
+            external_effect="none",
+            structurally_safe=True,
+            release_blocking=False,
+            operator_action=False,
+            live_lease=live_lease,
+            reason_code="apple-history-proves-submission-absent",
         )
     if marker is None and stage is None:
         return _record(
@@ -1714,6 +1810,16 @@ def _inspect_transaction_directory(
                 expected_device=expected_device,
             )
         )
+        reconciliation = (
+            _read_reconciliation_marker(
+                descriptor,
+                expected_device=expected_device,
+                transaction_id=state_transaction_id or "",
+                state_context=state_context,
+            )
+            if "notary-reconciliation.json" in names_before
+            else None
+        )
         if stage is not None and not _REQUIRED_TRANSACTION_DIRECTORIES.issubset(
             names_before
         ):
@@ -1775,6 +1881,7 @@ def _inspect_transaction_directory(
             ),
             expected_archive_name=expected_archive_name,
             live_lease=live_lease,
+            reconciliation=reconciliation,
         )
     except NotaryTransactionInspectionError as error:
         return _record(

--- a/scripts/tests/test_notarize_direct_transaction.py
+++ b/scripts/tests/test_notarize_direct_transaction.py
@@ -903,6 +903,132 @@ class DirectNotaryTransactionTests(unittest.TestCase):
                 )
             )
 
+    def test_mismatched_submit_intent_without_history_is_retired_and_released(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            paths = self.fixture(root)
+            with self.assertRaisesRegex(
+                MODULE.DirectNotaryTransactionError,
+                "submission",
+            ):
+                MODULE.run_transaction(
+                    project_root=root,
+                    app=paths["app"],
+                    manifest=paths["manifest"],
+                    evidence=paths["evidence"],
+                    attestation=paths["attestation"],
+                    release_channel="public-alpha",
+                    notary_profile="test-profile",
+                    runner=FakeReleaseRunner(fail_submit=True),
+                    **self.source_kwargs(root, commit="a"),
+                )
+
+            runner = FakeReleaseRunner()
+            result = MODULE.run_transaction(
+                project_root=root,
+                app=paths["app"],
+                manifest=paths["manifest"],
+                evidence=paths["evidence"],
+                attestation=paths["attestation"],
+                release_channel="public-alpha",
+                notary_profile="test-profile",
+                runner=runner,
+                **self.source_kwargs(root, commit="d"),
+            )
+
+            self.assertTrue(Path(result["archive"]).is_file())
+            self.assertEqual(
+                sum(
+                    command[:3] == ["xcrun", "notarytool", "submit"]
+                    for command in runner.commands
+                ),
+                1,
+            )
+            self.assertTrue(
+                any(
+                    command[:3] == ["xcrun", "notarytool", "history"]
+                    for command in runner.commands
+                )
+            )
+            retired = list((root / "dist" / ".notary-retired").iterdir())
+            reconciled = [
+                path
+                for path in retired
+                if (path / "notary-reconciliation.json").is_file()
+            ]
+            self.assertEqual(len(reconciled), 1)
+            marker = json.loads(
+                (reconciled[0] / "notary-reconciliation.json").read_text()
+            )
+            self.assertEqual(marker["result"], "submission-absent")
+            self.assertEqual(
+                marker["archiveName"],
+                "NeAntik-1.2.3-arm64-notarized.zip",
+            )
+
+    def test_mismatched_submit_intent_with_history_remains_blocking(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            paths = self.fixture(root)
+            with self.assertRaisesRegex(
+                MODULE.DirectNotaryTransactionError,
+                "submission",
+            ):
+                MODULE.run_transaction(
+                    project_root=root,
+                    app=paths["app"],
+                    manifest=paths["manifest"],
+                    evidence=paths["evidence"],
+                    attestation=paths["attestation"],
+                    release_channel="public-alpha",
+                    notary_profile="test-profile",
+                    runner=FakeReleaseRunner(fail_submit=True),
+                    **self.source_kwargs(root, commit="a"),
+                )
+            active = MODULE.STATE.find_active_transaction(
+                root / "dist",
+                "NeAntik-1.2.3-arm64-notarized.zip",
+            )
+            assert active is not None
+            submission_name = MODULE._receipt_data(
+                active[1],
+                "transaction-created",
+            )["submissionName"]
+            runner = FakeReleaseRunner(
+                history_submission_name=str(submission_name),
+            )
+            with self.assertRaisesRegex(
+                MODULE.DirectNotaryTransactionError,
+                "matching Apple submission",
+            ):
+                MODULE.run_transaction(
+                    project_root=root,
+                    app=paths["app"],
+                    manifest=paths["manifest"],
+                    evidence=paths["evidence"],
+                    attestation=paths["attestation"],
+                    release_channel="public-alpha",
+                    notary_profile="test-profile",
+                    runner=runner,
+                    **self.source_kwargs(root, commit="d"),
+                )
+            self.assertFalse(
+                any(
+                    command[:3] == ["xcrun", "notarytool", "submit"]
+                    for command in runner.commands
+                )
+            )
+            self.assertIsNotNone(
+                MODULE.STATE.find_active_transaction(
+                    root / "dist",
+                    "NeAntik-1.2.3-arm64-notarized.zip",
+                )
+            )
+
     def test_sidecar_crash_resumes_exact_transaction_without_resubmit(
         self,
     ) -> None:

--- a/scripts/tests/test_notary_transaction_inspector.py
+++ b/scripts/tests/test_notary_transaction_inspector.py
@@ -203,6 +203,25 @@ def create_transaction(
     return root
 
 
+def write_reconciliation_marker(root: Path, transaction_id: str) -> None:
+    submission_name = f"{transaction_id}-{ARCHIVE}"
+    write_private(
+        root / "notary-reconciliation.json",
+        {
+            "archiveName": ARCHIVE,
+            "checkedAtUnixNs": 1,
+            "historySHA256": "a" * 64,
+            "markerType": "neantik-notary-reconciliation",
+            "result": "submission-absent",
+            "schemaVersion": 1,
+            "submissionNameSHA256": hashlib.sha256(
+                submission_name.encode("utf-8")
+            ).hexdigest(),
+            "transactionId": transaction_id,
+        },
+    )
+
+
 def tree_snapshot(root: Path) -> tuple[tuple[object, ...], ...]:
     rows = []
     for path in sorted((root, *root.rglob("*"))):
@@ -372,6 +391,55 @@ class NotaryTransactionInspectorTests(unittest.TestCase):
         self.assertEqual(
             report["records"][0]["reasonCode"],
             "retired-state-requires-reconciliation",
+        )
+
+    def test_reconciled_retired_submit_intent_is_non_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            dist = Path(temporary) / "dist"
+            dist.mkdir()
+            transaction_id = str(uuid.uuid4())
+            root = create_transaction(
+                dist,
+                category="retired",
+                stage="submit-intent",
+                transaction_id=transaction_id,
+            )
+            write_reconciliation_marker(root, transaction_id)
+            report = MODULE.inspect_dist(
+                dist,
+                expected_archive_name=ARCHIVE,
+            )
+        self.assertTrue(report["safe"])
+        self.assertTrue(report["releaseReady"])
+        self.assertEqual(report["summary"]["retiredCount"], 1)
+        self.assertEqual(report["records"], [])
+
+    def test_malformed_reconciliation_marker_is_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            dist = Path(temporary) / "dist"
+            dist.mkdir()
+            transaction_id = str(uuid.uuid4())
+            root = create_transaction(
+                dist,
+                category="retired",
+                stage="submit-intent",
+                transaction_id=transaction_id,
+            )
+            write_reconciliation_marker(root, transaction_id)
+            marker_path = root / "notary-reconciliation.json"
+            marker = json.loads(marker_path.read_text())
+            marker["submissionNameSHA256"] = "0" * 64
+            marker_path.chmod(0o600)
+            write_private(marker_path, marker)
+            report = MODULE.inspect_dist(
+                dist,
+                expected_archive_name=ARCHIVE,
+            )
+        self.assertFalse(report["safe"])
+        self.assertFalse(report["releaseReady"])
+        self.assertEqual(
+            report["records"][0]["reasonCode"],
+            "invalid-reconciliation-schema",
         )
 
     def test_realistic_independent_retirement_uuid_is_safe(self) -> None:


### PR DESCRIPTION
Исправляет блокировку Direct release после прерванного `notarytool submit`, когда исходный commit уже изменился.

- сверяет уникальное имя старой отправки через Apple notary history;
- найденную отправку оставляет блокирующей без повторного submit;
- доказанное отсутствие фиксирует приватным неизменяемым маркером и безопасно переносит транзакцию в retained history;
- инспектор учитывает reconciled state без ослабления fail-closed проверок;
- добавлены регрессии для no-effect, known-effect и malformed marker.

Локально: 480 Python tests OK (1 skipped); targeted 62 OK (1 skipped). Direct Distribution only.