### PR TITLE
Fix Apple no-wait parsing and DMG source

### DIFF
--- a/scripts/notarize_direct_transaction.py
+++ b/scripts/notarize_direct_transaction.py
@@ -274,12 +274,13 @@ def parse_notary_submission(output: str) -> str:
         )
     identifier = payload.get("id")
     status_value = payload.get("status")
-    if not isinstance(identifier, str) or not isinstance(
-        status_value,
-        str,
-    ):
+    if not isinstance(identifier, str):
         raise DirectNotaryTransactionError(
-            "Apple notary submission is missing id or status"
+            "Apple notary submission is missing id"
+        )
+    if status_value is not None and not isinstance(status_value, str):
+        raise DirectNotaryTransactionError(
+            "Apple notary submission status is invalid"
         )
     try:
         canonical_identifier = str(uuid.UUID(identifier))
@@ -291,7 +292,10 @@ def parse_notary_submission(output: str) -> str:
         raise DirectNotaryTransactionError(
             "Apple notary submission id is not canonical"
         )
-    if status_value not in {"Accepted", "In Progress"}:
+    if (
+        status_value is not None
+        and status_value not in {"Accepted", "In Progress"}
+    ):
         raise DirectNotaryTransactionError(
             f"Apple notarization submission status is {status_value}"
         )

--- a/scripts/release-direct-dmg.sh
+++ b/scripts/release-direct-dmg.sh
@@ -3,9 +3,8 @@
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-APP_PATH="$PROJECT_DIR/dist/NeAntik.app"
-INFO_PLIST="$APP_PATH/Contents/Info.plist"
-RUNTIME_APP="$APP_PATH/Contents/Resources/NeAntik Browser.app"
+PREPARED_APP_PATH="$PROJECT_DIR/dist/NeAntik.app"
+PREPARED_INFO_PLIST="$PREPARED_APP_PATH/Contents/Info.plist"
 NOTARY_PROFILE="${NEANTIK_NOTARY_PROFILE:-neantik-notary}"
 NOTARY_LOG_DIR="$PROJECT_DIR/dist/notary"
 
@@ -14,34 +13,39 @@ fail() {
   exit 65
 }
 
-[[ -d "$APP_PATH" ]] || fail "missing signed app: $APP_PATH"
-[[ -f "$INFO_PLIST" ]] || fail "missing app Info.plist"
-[[ -d "$RUNTIME_APP" ]] || fail "embedded NeAntik Browser runtime is missing"
+[[ -d "$PREPARED_APP_PATH" ]] ||
+  fail "missing signed app: $PREPARED_APP_PATH"
+[[ -f "$PREPARED_INFO_PLIST" ]] ||
+  fail "missing app Info.plist"
 
 VERSION="$(
   /usr/libexec/PlistBuddy \
     -c 'Print :CFBundleShortVersionString' \
-    "$INFO_PLIST"
+    "$PREPARED_INFO_PLIST"
 )"
 BUILD="$(
   /usr/libexec/PlistBuddy \
     -c 'Print :CFBundleVersion' \
-    "$INFO_PLIST"
+    "$PREPARED_INFO_PLIST"
 )"
 [[ -n "$VERSION" && -n "$BUILD" ]] || fail "app version/build is missing"
 
+ZIP_PATH="$PROJECT_DIR/dist/NeAntik-$VERSION-arm64-notarized.zip"
 DMG_PATH="$PROJECT_DIR/dist/NeAntik-$VERSION-arm64-notarized.dmg"
 CHECKSUM_PATH="$DMG_PATH.sha256"
+[[ -f "$ZIP_PATH" ]] ||
+  fail "notarized ZIP is required before DMG creation: $ZIP_PATH"
 [[ ! -e "$DMG_PATH" ]] ||
   fail "final DMG already exists; verify or move it before rebuilding: $DMG_PATH"
 [[ ! -e "$CHECKSUM_PATH" ]] ||
   fail "DMG checksum already exists; verify or move it before rebuilding: $CHECKSUM_PATH"
 
-APP_SIZE_KB="$(du -sk "$APP_PATH" | awk '{print $1}')"
-(( APP_SIZE_KB >= 100000 )) ||
-  fail "app is unexpectedly small (${APP_SIZE_KB} KB); refusing to create an empty DMG"
+python3 "$PROJECT_DIR/scripts/verify-direct-notarized-archive.py" \
+  --project-root "$PROJECT_DIR" \
+  --archive "$ZIP_PATH"
 
 TEMP_ROOT="$(mktemp -d -t neantik-dmg-release)"
+ARCHIVE_ROOT="$TEMP_ROOT/archive"
 STAGING_DIR="$TEMP_ROOT/staging"
 MOUNT_POINT="$TEMP_ROOT/mount"
 TEMP_DMG="$TEMP_ROOT/$(basename "$DMG_PATH")"
@@ -54,6 +58,35 @@ cleanup() {
   rm -rf "$TEMP_ROOT"
 }
 trap cleanup EXIT
+
+mkdir -p "$ARCHIVE_ROOT"
+ditto -x -k "$ZIP_PATH" "$ARCHIVE_ROOT"
+APP_PATH="$ARCHIVE_ROOT/NeAntik.app"
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+RUNTIME_APP="$APP_PATH/Contents/Resources/NeAntik Browser.app"
+
+[[ -d "$APP_PATH" ]] ||
+  fail "notarized ZIP does not contain NeAntik.app"
+[[ -f "$INFO_PLIST" ]] ||
+  fail "notarized ZIP app has no Info.plist"
+[[ -d "$RUNTIME_APP" ]] ||
+  fail "notarized ZIP app has no embedded NeAntik Browser runtime"
+[[ "$(
+  /usr/libexec/PlistBuddy \
+    -c 'Print :CFBundleShortVersionString' \
+    "$INFO_PLIST"
+)" == "$VERSION" ]] ||
+  fail "notarized ZIP app version does not match the prepared candidate"
+[[ "$(
+  /usr/libexec/PlistBuddy \
+    -c 'Print :CFBundleVersion' \
+    "$INFO_PLIST"
+)" == "$BUILD" ]] ||
+  fail "notarized ZIP app build does not match the prepared candidate"
+
+APP_SIZE_KB="$(du -sk "$APP_PATH" | awk '{print $1}')"
+(( APP_SIZE_KB >= 100000 )) ||
+  fail "app is unexpectedly small (${APP_SIZE_KB} KB); refusing to create an empty DMG"
 
 codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 xcrun stapler validate "$APP_PATH"

--- a/scripts/tests/test_direct_dmg_release_scripts.py
+++ b/scripts/tests/test_direct_dmg_release_scripts.py
@@ -8,7 +8,20 @@ ROOT = Path(__file__).resolve().parents[2]
 class DirectDMGReleaseScriptTests(unittest.TestCase):
     def test_release_script_fails_closed_before_notarization(self) -> None:
         text = (ROOT / "scripts" / "release-direct-dmg.sh").read_text()
-        self.assertIn('APP_PATH="$PROJECT_DIR/dist/NeAntik.app"', text)
+        self.assertIn(
+            'PREPARED_APP_PATH="$PROJECT_DIR/dist/NeAntik.app"',
+            text,
+        )
+        self.assertIn(
+            'ZIP_PATH="$PROJECT_DIR/dist/NeAntik-$VERSION-arm64-notarized.zip"',
+            text,
+        )
+        self.assertIn(
+            'verify-direct-notarized-archive.py',
+            text,
+        )
+        self.assertIn('ditto -x -k "$ZIP_PATH" "$ARCHIVE_ROOT"', text)
+        self.assertIn('APP_PATH="$ARCHIVE_ROOT/NeAntik.app"', text)
         self.assertIn('RUNTIME_APP="$APP_PATH/Contents/Resources/NeAntik Browser.app"', text)
         self.assertIn("APP_SIZE_KB >= 100000", text)
         self.assertIn("DMG_SIZE >= 50000000", text)

--- a/scripts/tests/test_notarize_direct_transaction.py
+++ b/scripts/tests/test_notarize_direct_transaction.py
@@ -100,7 +100,6 @@ class FakeReleaseRunner:
                 json.dumps(
                     {
                         "id": SUBMISSION_ID,
-                        "status": self.notary_status,
                     }
                 ),
             )
@@ -156,6 +155,41 @@ class FakeReleaseRunner:
 
 
 class DirectNotaryTransactionTests(unittest.TestCase):
+    def test_no_wait_submission_accepts_identifier_without_status(
+        self,
+    ) -> None:
+        self.assertEqual(
+            MODULE.parse_notary_submission(
+                json.dumps({"id": SUBMISSION_ID})
+            ),
+            SUBMISSION_ID,
+        )
+
+    def test_no_wait_submission_rejects_missing_identifier(self) -> None:
+        with self.assertRaisesRegex(
+            MODULE.DirectNotaryTransactionError,
+            "missing id",
+        ):
+            MODULE.parse_notary_submission(
+                json.dumps({"message": "Successfully uploaded file"})
+            )
+
+    def test_no_wait_submission_rejects_invalid_optional_status(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            MODULE.DirectNotaryTransactionError,
+            "status is Rejected",
+        ):
+            MODULE.parse_notary_submission(
+                json.dumps(
+                    {
+                        "id": SUBMISSION_ID,
+                        "status": "Rejected",
+                    }
+                )
+            )
+
     def source_kwargs(
         self,
         root: Path,


### PR DESCRIPTION
Fixes the two Direct release defects found while completing 0.3.15.

1. Apple `notarytool submit --no-wait` can return a canonical submission ID without status; status belongs to the later wait/info phase. The parser now accepts absent optional status while retaining strict UUID and present-status validation.
2. The DMG stage previously read `dist/NeAntik.app`, whose staple ticket predates the just-completed ZIP transaction. It now verifies the final notarized ZIP, extracts its freshly stapled app into a private temporary directory, checks version/build/runtime, and uses that exact app for DMG creation.

Regression coverage:
- realistic no-wait fake response;
- absent status accepted; invalid/missing ID and invalid present status rejected;
- DMG script contract requires verified ZIP extraction.

Local: targeted 40 passed; full Python 483 passed, 1 skipped. Direct Distribution only.