### PR TITLE
Bind Direct candidate to exact source commit

### DIFF
--- a/scripts/Run-NeAntik-Release.command
+++ b/scripts/Run-NeAntik-Release.command
@@ -6,6 +6,7 @@ PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SOURCE_APP="$PROJECT_DIR/dist/NeAntik-Integrated.app"
 APP_PATH="$PROJECT_DIR/dist/NeAntik.app"
 CANDIDATE_MANIFEST="$PROJECT_DIR/dist/direct-candidate-manifest.json"
+CANDIDATE_SOURCE_BINDING="$PROJECT_DIR/dist/direct-candidate-source.json"
 REPORT_PATH="$PROJECT_DIR/dist/fingerprint-audit.json"
 ATTEMPT_STATE_ROOT="$PROJECT_DIR/artifacts/neantik/private-release-attempts/$(date -u '+%Y%m%dT%H%M%SZ')-$$"
 DEFAULT_SOURCE_PROVENANCE="/private/tmp/nevision-chromium-151/build/source-provenance.json"
@@ -128,6 +129,10 @@ prepare_candidate() {
     "$ATTEMPT_STATE_ROOT/prepare-candidate.log" \
     "$PROJECT_DIR/scripts/prepare-direct-manager-update.sh" \
     "$SOURCE_APP"
+  python3 "$PROJECT_DIR/scripts/direct-candidate-source-binding.py" create \
+    --project-root "$PROJECT_DIR" \
+    --manifest "$CANDIDATE_MANIFEST" \
+    --binding "$CANDIDATE_SOURCE_BINDING"
 }
 
 echo "NeAntik $EXPECTED_VERSION — защищённый локальный этап выпуска"
@@ -141,7 +146,9 @@ echo "Private attempt state: $ATTEMPT_STATE_ROOT"
 cache_runtime_source_evidence
 
 if [[ -d "$APP_PATH" && -f "$CANDIDATE_MANIFEST" &&
-      ! -L "$CANDIDATE_MANIFEST" ]]; then
+      ! -L "$CANDIDATE_MANIFEST" &&
+      -f "$CANDIDATE_SOURCE_BINDING" &&
+      ! -L "$CANDIDATE_SOURCE_BINDING" ]]; then
   echo "Проверяю уже подготовленный кандидат."
   NEEDS_REBUILD=0
   if ! python3 "$PROJECT_DIR/scripts/direct-candidate-manifest.py" verify \
@@ -149,6 +156,13 @@ if [[ -d "$APP_PATH" && -f "$CANDIDATE_MANIFEST" &&
       --manifest "$CANDIDATE_MANIFEST" \
       --release-channel "$NEANTIK_RELEASE_CHANNEL" \
       >"$ATTEMPT_STATE_ROOT/candidate-reuse-check.log" 2>&1; then
+    NEEDS_REBUILD=1
+  fi
+  if ! python3 "$PROJECT_DIR/scripts/direct-candidate-source-binding.py" verify \
+      --project-root "$PROJECT_DIR" \
+      --manifest "$CANDIDATE_MANIFEST" \
+      --binding "$CANDIDATE_SOURCE_BINDING" \
+      >>"$ATTEMPT_STATE_ROOT/candidate-reuse-check.log" 2>&1; then
     NEEDS_REBUILD=1
   fi
   CANDIDATE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_PATH/Contents/Info.plist" 2>/dev/null || true)"
@@ -162,18 +176,25 @@ if [[ -d "$APP_PATH" && -f "$CANDIDATE_MANIFEST" &&
     echo "Кандидат изменился; переношу его в private attempt state."
     mv "$APP_PATH" "$ATTEMPT_STATE_ROOT/previous-NeAntik.app"
     mv "$CANDIDATE_MANIFEST" "$ATTEMPT_STATE_ROOT/previous-direct-candidate-manifest.json"
+    mv "$CANDIDATE_SOURCE_BINDING" "$ATTEMPT_STATE_ROOT/previous-direct-candidate-source.json"
     prepare_candidate
   else
     echo "[1/4] PASS: использую неизменившийся кандидат $EXPECTED_VERSION ($EXPECTED_BUILD)."
   fi
 elif [[ -e "$APP_PATH" || -e "$CANDIDATE_MANIFEST" ||
-        -L "$CANDIDATE_MANIFEST" ]]; then
+        -L "$CANDIDATE_MANIFEST" ||
+        -e "$CANDIDATE_SOURCE_BINDING" ||
+        -L "$CANDIDATE_SOURCE_BINDING" ]]; then
   echo "Найден неполный локальный кандидат; переношу его в private attempt state."
   if [[ -e "$APP_PATH" ]]; then
     mv "$APP_PATH" "$ATTEMPT_STATE_ROOT/previous-NeAntik.app"
   fi
   if [[ -e "$CANDIDATE_MANIFEST" || -L "$CANDIDATE_MANIFEST" ]]; then
     mv "$CANDIDATE_MANIFEST" "$ATTEMPT_STATE_ROOT/previous-direct-candidate-manifest.json"
+  fi
+  if [[ -e "$CANDIDATE_SOURCE_BINDING" ||
+        -L "$CANDIDATE_SOURCE_BINDING" ]]; then
+    mv "$CANDIDATE_SOURCE_BINDING" "$ATTEMPT_STATE_ROOT/previous-direct-candidate-source.json"
   fi
   prepare_candidate
 else
@@ -283,6 +304,11 @@ done
 python3 "$PROJECT_DIR/scripts/wait-for-neantik-runtime-drain.py" \
   --app "$APP_PATH" \
   --timeout 45
+
+python3 "$PROJECT_DIR/scripts/direct-candidate-source-binding.py" verify \
+  --project-root "$PROJECT_DIR" \
+  --manifest "$CANDIDATE_MANIFEST" \
+  --binding "$CANDIDATE_SOURCE_BINDING"
 
 echo "[3/4] Отправляю кандидат в Apple notarization…"
 "$PROJECT_DIR/scripts/notarize-direct-candidate.sh"

--- a/scripts/direct-candidate-source-binding.py
+++ b/scripts/direct-candidate-source-binding.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Bind one prepared Direct candidate to the exact clean Git source commit."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+MAXIMUM_BINDING_BYTES = 4096
+HEX_40 = re.compile(r"[0-9a-f]{40}")
+HEX_64 = re.compile(r"[0-9a-f]{64}")
+
+
+class CandidateSourceBindingError(RuntimeError):
+    pass
+
+
+def run_git(project_root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(project_root), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise CandidateSourceBindingError("Git source query failed")
+    return result.stdout.strip()
+
+
+def checked_project_root(project_root: Path) -> Path:
+    root = project_root.resolve()
+    if not root.is_dir():
+        raise CandidateSourceBindingError("project root is unavailable")
+    top_level = Path(run_git(root, "rev-parse", "--show-toplevel")).resolve()
+    if top_level != root:
+        raise CandidateSourceBindingError(
+            "project root must be the exact Git worktree root"
+        )
+    if run_git(root, "status", "--porcelain", "--untracked-files=no"):
+        raise CandidateSourceBindingError(
+            "tracked release source is not clean"
+        )
+    return root
+
+
+def regular_file_bytes(path: Path, maximum_bytes: int) -> bytes:
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise CandidateSourceBindingError(
+            f"{path.name} is unavailable"
+        ) from error
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_uid != os.geteuid()
+            or before.st_nlink != 1
+            or before.st_mode & 0o022
+            or before.st_size <= 0
+            or before.st_size > maximum_bytes
+        ):
+            raise CandidateSourceBindingError(
+                f"{path.name} is unsafe"
+            )
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = os.read(descriptor, min(1024 * 1024, maximum_bytes + 1))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > maximum_bytes:
+                break
+        raw = b"".join(chunks)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    if (
+        len(raw) != before.st_size
+        or len(raw) > maximum_bytes
+        or before.st_dev != after.st_dev
+        or before.st_ino != after.st_ino
+        or before.st_mtime_ns != after.st_mtime_ns
+        or before.st_ctime_ns != after.st_ctime_ns
+    ):
+        raise CandidateSourceBindingError(
+            f"{path.name} changed while it was read"
+        )
+    return raw
+
+
+def expected_payload(
+    project_root: Path,
+    manifest: Path,
+) -> dict[str, object]:
+    root = checked_project_root(project_root)
+    commit = run_git(root, "rev-parse", "HEAD")
+    tree = run_git(root, "rev-parse", "HEAD^{tree}")
+    if not HEX_40.fullmatch(commit) or not HEX_40.fullmatch(tree):
+        raise CandidateSourceBindingError(
+            "unsupported Git object format"
+        )
+    manifest_raw = regular_file_bytes(manifest, 16 * 1024 * 1024)
+    return {
+        "commit": commit,
+        "manifestSHA256": hashlib.sha256(manifest_raw).hexdigest(),
+        "schemaVersion": 1,
+        "tree": tree,
+    }
+
+
+def encoded_payload(payload: dict[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def create_binding(
+    project_root: Path,
+    manifest: Path,
+    binding: Path,
+) -> str:
+    if binding.exists() or binding.is_symlink():
+        raise CandidateSourceBindingError(
+            "candidate source binding already exists"
+        )
+    payload = expected_payload(project_root, manifest)
+    raw = encoded_payload(payload)
+    binding.parent.mkdir(parents=True, exist_ok=True)
+    temporary_descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{binding.name}.",
+        dir=binding.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(temporary_descriptor, 0o600)
+        with os.fdopen(temporary_descriptor, "wb") as handle:
+            handle.write(raw)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(temporary, binding)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return hashlib.sha256(raw).hexdigest()
+
+
+def verify_binding(
+    project_root: Path,
+    manifest: Path,
+    binding: Path,
+) -> str:
+    raw = regular_file_bytes(binding, MAXIMUM_BINDING_BYTES)
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise CandidateSourceBindingError(
+            "candidate source binding is invalid"
+        ) from error
+    expected = expected_payload(project_root, manifest)
+    if payload != expected or raw != encoded_payload(expected):
+        raise CandidateSourceBindingError(
+            "prepared candidate does not match the exact current source commit"
+        )
+    digest = hashlib.sha256(raw).hexdigest()
+    if not HEX_64.fullmatch(digest):
+        raise CandidateSourceBindingError(
+            "candidate source binding digest is invalid"
+        )
+    return digest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=("create", "verify"))
+    parser.add_argument("--project-root", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--binding", type=Path, required=True)
+    arguments = parser.parse_args()
+    try:
+        if arguments.action == "create":
+            digest = create_binding(
+                arguments.project_root,
+                arguments.manifest,
+                arguments.binding,
+            )
+        else:
+            digest = verify_binding(
+                arguments.project_root,
+                arguments.manifest,
+                arguments.binding,
+            )
+    except CandidateSourceBindingError as error:
+        print(f"Candidate source binding failed: {error}", file=os.sys.stderr)
+        return 65
+    print(f"PASS: candidate source binding verified; SHA-256 {digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_direct_candidate_source_binding.py
+++ b/scripts/tests/test_direct_candidate_source_binding.py
@@ -1,0 +1,102 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "direct-candidate-source-binding.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "direct_candidate_source_binding",
+    SCRIPT,
+)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def git(root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *arguments],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+class DirectCandidateSourceBindingTests(unittest.TestCase):
+    def fixture(self, root: Path) -> tuple[Path, Path]:
+        git(root, "init", "-q")
+        git(root, "config", "user.email", "tests@example.invalid")
+        git(root, "config", "user.name", "NeAntik Tests")
+        source = root / "source.txt"
+        source.write_text("first\n", encoding="utf-8")
+        git(root, "add", "source.txt")
+        git(root, "commit", "-qm", "initial")
+        manifest = root / "candidate.json"
+        manifest.write_text('{"schemaVersion":3}', encoding="utf-8")
+        binding = root / "binding.json"
+        return manifest, binding
+
+    def test_round_trip_binds_commit_tree_and_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest, binding = self.fixture(root)
+
+            created = MODULE.create_binding(root, manifest, binding)
+            verified = MODULE.verify_binding(root, manifest, binding)
+            payload = json.loads(binding.read_text(encoding="utf-8"))
+
+            self.assertEqual(created, verified)
+            self.assertEqual(payload["commit"], git(root, "rev-parse", "HEAD"))
+            self.assertEqual(
+                payload["tree"],
+                git(root, "rev-parse", "HEAD^{tree}"),
+            )
+            self.assertEqual(binding.stat().st_mode & 0o777, 0o600)
+
+    def test_rejects_new_commit_even_when_candidate_is_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest, binding = self.fixture(root)
+            MODULE.create_binding(root, manifest, binding)
+            (root / "source.txt").write_text("second\n", encoding="utf-8")
+            git(root, "add", "source.txt")
+            git(root, "commit", "-qm", "next")
+
+            with self.assertRaisesRegex(
+                MODULE.CandidateSourceBindingError,
+                "exact current source commit",
+            ):
+                MODULE.verify_binding(root, manifest, binding)
+
+    def test_rejects_manifest_drift_and_dirty_tracked_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest, binding = self.fixture(root)
+            MODULE.create_binding(root, manifest, binding)
+            manifest.write_text('{"schemaVersion":4}', encoding="utf-8")
+            with self.assertRaisesRegex(
+                MODULE.CandidateSourceBindingError,
+                "exact current source commit",
+            ):
+                MODULE.verify_binding(root, manifest, binding)
+
+            manifest.write_text('{"schemaVersion":3}', encoding="utf-8")
+            (root / "source.txt").write_text("dirty\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                MODULE.CandidateSourceBindingError,
+                "not clean",
+            ):
+                MODULE.verify_binding(root, manifest, binding)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_runtime_evidence_cache.py
+++ b/scripts/tests/test_release_runtime_evidence_cache.py
@@ -36,6 +36,35 @@ class ReleaseRuntimeEvidenceCacheTests(unittest.TestCase):
         self.assertIn("-type f -name source-provenance.json", text)
         self.assertIn('lock="$evidence_dir/fingerprint-chromium.lock.json"', text)
 
+    def test_release_reuses_only_candidate_from_exact_current_source(self) -> None:
+        text = RELEASE_COMMAND.read_text(encoding="utf-8")
+
+        self.assertIn(
+            'CANDIDATE_SOURCE_BINDING="$PROJECT_DIR/dist/direct-candidate-source.json"',
+            text,
+        )
+        self.assertIn("direct-candidate-source-binding.py", text)
+        self.assertIn("--project-root \"$PROJECT_DIR\"", text)
+        self.assertIn("--binding \"$CANDIDATE_SOURCE_BINDING\"", text)
+        self.assertIn(
+            'mv "$CANDIDATE_SOURCE_BINDING" '
+            '"$ATTEMPT_STATE_ROOT/previous-direct-candidate-source.json"',
+            text,
+        )
+        source_verifications = [
+            index
+            for index in range(len(text))
+            if text.startswith(
+                'python3 "$PROJECT_DIR/scripts/direct-candidate-source-binding.py" verify',
+                index,
+            )
+        ]
+        self.assertEqual(len(source_verifications), 2)
+        self.assertLess(
+            source_verifications[-1],
+            text.index("[3/4] Отправляю кандидат в Apple notarization…"),
+        )
+
     def test_release_waits_before_retrying_gui_audit(self) -> None:
         text = RELEASE_COMMAND.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Что исправлено

- запрещено повторное использование локального NeAntik.app, если изменился Git commit, tree или candidate manifest
- устаревший кандидат переносится в private attempt state без удаления
- source binding повторно проверяется непосредственно перед notarization
- добавлены fail-closed тесты для нового commit, manifest drift и dirty source

## Проверки

- 539 Python tests, 1 platform skip
- targeted source-binding/release-runner tests
- zsh -n, git diff --check

Direct Distribution only; App Store не затрагивается.