### PR TITLE
Pin candidate source inside notarization transaction

### DIFF
--- a/scripts/direct-candidate-source-binding.py
+++ b/scripts/direct-candidate-source-binding.py
@@ -44,9 +44,15 @@ def checked_project_root(project_root: Path) -> Path:
         raise CandidateSourceBindingError(
             "project root must be the exact Git worktree root"
         )
-    if run_git(root, "status", "--porcelain", "--untracked-files=no"):
+    if run_git(
+        root,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        "--ignored=no",
+    ):
         raise CandidateSourceBindingError(
-            "tracked release source is not clean"
+            "release source is not clean"
         )
     return root
 

--- a/scripts/notarize-direct-candidate.sh
+++ b/scripts/notarize-direct-candidate.sh
@@ -7,6 +7,7 @@ PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 APP_PATH="$PROJECT_DIR/dist/NeAntik.app"
 REPORT_PATH="$PROJECT_DIR/dist/fingerprint-audit.json"
 CANDIDATE_MANIFEST="$PROJECT_DIR/dist/direct-candidate-manifest.json"
+CANDIDATE_SOURCE_BINDING="$PROJECT_DIR/dist/direct-candidate-source.json"
 SUMMARY_PATH="$PROJECT_DIR/dist/fingerprint-audit-summary.json"
 
 : "${NEANTIK_NOTARY_PROFILE:?Set NEANTIK_NOTARY_PROFILE to a notarytool Keychain profile}"
@@ -51,6 +52,7 @@ exec "$RELEASE_PYTHON" -I -B \
   --project-root "$PROJECT_DIR" \
   --app "$APP_PATH" \
   --manifest "$CANDIDATE_MANIFEST" \
+  --source-binding "$CANDIDATE_SOURCE_BINDING" \
   --evidence "$REPORT_PATH" \
   --attestation "$SUMMARY_PATH" \
   --release-channel "$NEANTIK_RELEASE_CHANNEL"

--- a/scripts/notarize_direct_transaction.py
+++ b/scripts/notarize_direct_transaction.py
@@ -28,6 +28,7 @@ import notary_transaction_state as STATE
 
 MAXIMUM_ARCHIVE_BYTES = 16 * 1024 * 1024 * 1024
 MAXIMUM_MANIFEST_BYTES = 16 * 1024 * 1024
+MAXIMUM_SOURCE_BINDING_BYTES = 4096
 MAXIMUM_EVIDENCE_BYTES = 8 * 1024 * 1024
 MAXIMUM_ATTESTATION_BYTES = 1024 * 1024
 MAXIMUM_INFO_PLIST_BYTES = 1024 * 1024
@@ -50,6 +51,7 @@ class CommandResult:
 class CandidateInputs:
     info: SNAPSHOT.ReleaseInputSnapshot
     manifest: SNAPSHOT.ReleaseInputSnapshot
+    source_binding: SNAPSHOT.ReleaseInputSnapshot
     evidence: SNAPSHOT.ReleaseInputSnapshot
     attestation: SNAPSHOT.ReleaseInputSnapshot
 
@@ -85,6 +87,7 @@ def rebase_candidate_inputs(
     return CandidateInputs(
         info=rebase(inputs.info),
         manifest=rebase(inputs.manifest),
+        source_binding=rebase(inputs.source_binding),
         evidence=rebase(inputs.evidence),
         attestation=rebase(inputs.attestation),
     )
@@ -101,6 +104,10 @@ def receipt_candidate_inputs(
         "manifest": {
             "sha256": inputs.manifest.sha256,
             "size": inputs.manifest.size,
+        },
+        "sourceBinding": {
+            "sha256": inputs.source_binding.sha256,
+            "size": inputs.source_binding.size,
         },
         "evidence": {
             "sha256": inputs.evidence.sha256,
@@ -519,6 +526,7 @@ def snapshot_candidate_inputs(
     *,
     info_plist: Path,
     manifest: Path,
+    source_binding: Path,
     evidence: Path,
     attestation: Path,
     destination: Path,
@@ -534,6 +542,11 @@ def snapshot_candidate_inputs(
                 manifest,
                 destination / "direct-candidate-manifest.json",
                 maximum_bytes=MAXIMUM_MANIFEST_BYTES,
+            ),
+            source_binding=SNAPSHOT.snapshot_release_input(
+                source_binding,
+                destination / "direct-candidate-source.json",
+                maximum_bytes=MAXIMUM_SOURCE_BINDING_BYTES,
             ),
             evidence=SNAPSHOT.snapshot_release_input(
                 evidence,
@@ -556,6 +569,7 @@ def assert_candidate_inputs_unchanged(inputs: CandidateInputs) -> None:
     for snapshot, maximum_bytes in (
         (inputs.info, MAXIMUM_INFO_PLIST_BYTES),
         (inputs.manifest, MAXIMUM_MANIFEST_BYTES),
+        (inputs.source_binding, MAXIMUM_SOURCE_BINDING_BYTES),
         (inputs.evidence, MAXIMUM_EVIDENCE_BYTES),
         (inputs.attestation, MAXIMUM_ATTESTATION_BYTES),
     ):
@@ -572,6 +586,46 @@ def assert_candidate_inputs_unchanged(inputs: CandidateInputs) -> None:
             raise DirectNotaryTransactionError(
                 "candidate release input changed during notarization"
             ) from error
+
+
+def validate_candidate_source_binding(
+    inputs: CandidateInputs,
+    release_source: SOURCE.ReleaseSourceSnapshot,
+) -> dict[str, object]:
+    try:
+        raw = inputs.source_binding.pinned.read_bytes()
+        payload = json.loads(
+            raw,
+            object_pairs_hook=_reject_duplicate_json_pairs,
+        )
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, TypeError) as error:
+        raise DirectNotaryTransactionError(
+            "candidate source binding is invalid"
+        ) from error
+    git = release_source.payload.get("git")
+    expected = {
+        "commit": git.get("commit") if isinstance(git, dict) else None,
+        "manifestSHA256": inputs.manifest.sha256,
+        "schemaVersion": 1,
+        "tree": git.get("tree") if isinstance(git, dict) else None,
+    }
+    canonical = json.dumps(
+        expected,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != set(expected)
+        or payload != expected
+        or raw != canonical
+    ):
+        raise DirectNotaryTransactionError(
+            "candidate source binding does not match the pinned "
+            "manifest and release source"
+        )
+    return payload
 
 
 def verify_candidate_app(
@@ -1289,6 +1343,7 @@ def _transaction_matches_current_release(
         == {
             "infoPlist": inputs.info.sha256,
             "manifest": inputs.manifest.sha256,
+            "sourceBinding": inputs.source_binding.sha256,
             "evidence": inputs.evidence.sha256,
             "attestation": inputs.attestation.sha256,
         }
@@ -2108,6 +2163,7 @@ def run_transaction(
     attestation: Path,
     release_channel: str,
     notary_profile: str,
+    source_binding: Path | None = None,
     runner: CommandRunner = default_runner,
     phase_hook: PhaseHook | None = None,
     source_snapshot: SOURCE.ReleaseSourceSnapshot | None = None,
@@ -2178,9 +2234,15 @@ def run_transaction(
             final_check_root,
         ):
             directory.mkdir(mode=0o700)
+        resolved_source_binding = (
+            source_binding
+            if source_binding is not None
+            else manifest.parent / "direct-candidate-source.json"
+        )
         inputs = snapshot_candidate_inputs(
             info_plist=project_root / "Resources" / "Info.plist",
             manifest=manifest,
+            source_binding=resolved_source_binding,
             evidence=evidence,
             attestation=attestation,
             destination=inputs_root,
@@ -2195,6 +2257,7 @@ def run_transaction(
                 "release source snapshot belongs to another worktree"
             )
         source_assertion(release_source)
+        validate_candidate_source_binding(inputs, release_source)
         bound_runtime_build_evidence = (
             runtime_build_evidence
             if runtime_build_evidence is not None
@@ -2204,6 +2267,7 @@ def run_transaction(
             )
         )
         context["manifest"] = inputs.manifest.pinned
+        context["source_binding"] = inputs.source_binding.pinned
         context["evidence"] = inputs.evidence.pinned
         context["attestation"] = inputs.attestation.pinned
         context["info"] = inputs.info.pinned
@@ -2279,6 +2343,7 @@ def run_transaction(
                 "candidateInputs": {
                     "infoPlist": inputs.info.sha256,
                     "manifest": inputs.manifest.sha256,
+                    "sourceBinding": inputs.source_binding.sha256,
                     "evidence": inputs.evidence.sha256,
                     "attestation": inputs.attestation.sha256,
                 },
@@ -2356,6 +2421,7 @@ def run_transaction(
         final_root = transaction_root / "final"
         final_check_root = transaction_root / "final-check"
         context["manifest"] = inputs.manifest.pinned
+        context["source_binding"] = inputs.source_binding.pinned
         context["evidence"] = inputs.evidence.pinned
         context["attestation"] = inputs.attestation.pinned
         context["info"] = inputs.info.pinned
@@ -2930,6 +2996,7 @@ def main() -> int:
     parser.add_argument("--project-root", type=Path, required=True)
     parser.add_argument("--app", type=Path, required=True)
     parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--source-binding", type=Path, required=True)
     parser.add_argument("--evidence", type=Path, required=True)
     parser.add_argument("--attestation", type=Path, required=True)
     parser.add_argument(
@@ -2944,6 +3011,7 @@ def main() -> int:
             project_root=args.project_root,
             app=args.app,
             manifest=args.manifest,
+            source_binding=args.source_binding,
             evidence=args.evidence,
             attestation=args.attestation,
             release_channel=args.release_channel,

--- a/scripts/tests/test_direct_candidate_source_binding.py
+++ b/scripts/tests/test_direct_candidate_source_binding.py
@@ -38,7 +38,11 @@ class DirectCandidateSourceBindingTests(unittest.TestCase):
         git(root, "config", "user.name", "NeAntik Tests")
         source = root / "source.txt"
         source.write_text("first\n", encoding="utf-8")
-        git(root, "add", "source.txt")
+        (root / ".gitignore").write_text(
+            "candidate.json\nbinding.json\n",
+            encoding="utf-8",
+        )
+        git(root, "add", "source.txt", ".gitignore")
         git(root, "commit", "-qm", "initial")
         manifest = root / "candidate.json"
         manifest.write_text('{"schemaVersion":3}', encoding="utf-8")
@@ -96,6 +100,20 @@ class DirectCandidateSourceBindingTests(unittest.TestCase):
                 "not clean",
             ):
                 MODULE.verify_binding(root, manifest, binding)
+
+    def test_rejects_untracked_swift_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest, binding = self.fixture(root)
+            untracked = root / "Sources/NeAntik/Injected.swift"
+            untracked.parent.mkdir(parents=True)
+            untracked.write_text("let injected = true\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                MODULE.CandidateSourceBindingError,
+                "not clean",
+            ):
+                MODULE.create_binding(root, manifest, binding)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_notarize_direct_transaction.py
+++ b/scripts/tests/test_notarize_direct_transaction.py
@@ -1,4 +1,5 @@
 import importlib.util
+import hashlib
 import json
 import os
 import plistlib
@@ -196,6 +197,7 @@ class DirectNotaryTransactionTests(unittest.TestCase):
         *,
         commit: str = "a",
     ) -> dict[str, object]:
+        tree = "b" * 40
         snapshot = MODULE.SOURCE.ReleaseSourceSnapshot(
             project_root=root.resolve(),
             payload={
@@ -205,7 +207,7 @@ class DirectNotaryTransactionTests(unittest.TestCase):
                 "git": {
                     "objectFormat": "sha1",
                     "commit": commit * 40,
-                    "tree": "b" * 40,
+                    "tree": tree,
                     "worktreeState": "clean",
                 },
                 "digestAlgorithm": "sha256",
@@ -214,6 +216,23 @@ class DirectNotaryTransactionTests(unittest.TestCase):
             },
             files=(),
         )
+        manifest = root / "dist" / "direct-candidate-manifest.json"
+        binding = root / "dist" / "direct-candidate-source.json"
+        binding.write_bytes(
+            json.dumps(
+                {
+                    "commit": commit * 40,
+                    "manifestSHA256": hashlib.sha256(
+                        manifest.read_bytes()
+                    ).hexdigest(),
+                    "schemaVersion": 1,
+                    "tree": tree,
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        )
+        binding.chmod(0o600)
         return {
             "source_snapshot": snapshot,
             "source_assertion": lambda _snapshot: None,
@@ -382,6 +401,7 @@ class DirectNotaryTransactionTests(unittest.TestCase):
                 for value in receipt["candidateInputs"].values()
             )
         )
+        self.assertIn("sourceBinding", receipt["candidateInputs"])
         self.assertEqual(
             receipt["releaseSource"]["git"]["commit"],
             "a" * 40,
@@ -401,6 +421,49 @@ class DirectNotaryTransactionTests(unittest.TestCase):
         self.assertEqual(checksum_mode, 0o400)
         self.assertEqual(len(accepted_receipts), 1)
         self.assertNotIn("test-profile", receipt_text)
+
+    def test_source_binding_must_match_pinned_manifest_and_release_source(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            paths = self.fixture(root)
+            source_kwargs = self.source_kwargs(root, commit="a")
+            binding = root / "dist" / "direct-candidate-source.json"
+            payload = json.loads(binding.read_text(encoding="utf-8"))
+            payload["commit"] = "d" * 40
+            binding.write_bytes(
+                json.dumps(
+                    payload,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ).encode("utf-8")
+            )
+            binding.chmod(0o600)
+            runner = FakeReleaseRunner()
+
+            with self.assertRaisesRegex(
+                MODULE.DirectNotaryTransactionError,
+                "does not match the pinned manifest and release source",
+            ):
+                MODULE.run_transaction(
+                    project_root=root,
+                    app=paths["app"],
+                    manifest=paths["manifest"],
+                    evidence=paths["evidence"],
+                    attestation=paths["attestation"],
+                    release_channel="public-alpha",
+                    notary_profile="test-profile",
+                    runner=runner,
+                    **source_kwargs,
+                )
+
+            self.assertFalse(
+                any(
+                    command[:3] == ["xcrun", "notarytool", "submit"]
+                    for command in runner.commands
+                )
+            )
 
     @unittest.skipUnless(
         hasattr(__import__("select"), "kqueue"),
@@ -602,6 +665,51 @@ class DirectNotaryTransactionTests(unittest.TestCase):
                 any(
                     command[:3]
                     == ["xcrun", "notarytool", "submit"]
+                    for command in runner.commands
+                )
+            )
+
+    def test_source_binding_write_restore_aborts_before_notary_submit(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            paths = self.fixture(root)
+            runner = FakeReleaseRunner()
+
+            def mutate_input(
+                phase: str,
+                _context: dict[str, Path],
+            ) -> None:
+                if phase == "inputs-pinned":
+                    binding = (
+                        root / "dist" / "direct-candidate-source.json"
+                    )
+                    original = binding.read_bytes()
+                    binding.write_bytes(b"changed")
+                    binding.write_bytes(original)
+                    binding.chmod(0o600)
+
+            with self.assertRaisesRegex(
+                MODULE.DirectNotaryTransactionError,
+                "input changed",
+            ):
+                MODULE.run_transaction(
+                    project_root=root,
+                    app=paths["app"],
+                    manifest=paths["manifest"],
+                    evidence=paths["evidence"],
+                    attestation=paths["attestation"],
+                    release_channel="public-alpha",
+                    notary_profile="test-profile",
+                    runner=runner,
+                    phase_hook=mutate_input,
+                    **self.source_kwargs(root),
+                )
+
+            self.assertFalse(
+                any(
+                    command[:3] == ["xcrun", "notarytool", "submit"]
                     for command in runner.commands
                 )
             )

--- a/scripts/tests/test_release_direct_script.py
+++ b/scripts/tests/test_release_direct_script.py
@@ -172,6 +172,8 @@ class ReleaseDirectScriptTests(unittest.TestCase):
         self.assertNotIn("notarytool submit", wrapper)
         self.assertNotIn("stapler", wrapper)
         self.assertIn("notarize_direct_transaction.py", wrapper)
+        self.assertIn("--source-binding", wrapper)
+        self.assertIn("direct-candidate-source.json", wrapper)
         self.assertIn("run-isolated-release-python.py", wrapper)
         self.assertIn("git -C \"$PROJECT_DIR\" ls-files -z -- '*.py'", wrapper)
         self.assertIn('python_cache="$python_parent/__pycache__"', wrapper)


### PR DESCRIPTION
## Исправление

- source binding теперь snapshot input самой notarization-транзакции
- commit/tree сверяются с pinned release source, manifest SHA — с pinned manifest
- binding hash входит в transaction state, Accepted/final receipts и resume matching
- untracked source, включая Swift-файлы, блокирует подготовку кандидата

## Проверки

- 542 Python tests, 1 platform skip
- mismatch/write-restore/recovery regression tests
- shell/Python syntax and git diff checks

Direct Distribution only.