### PR TITLE
Harden notarization resume and AffPapa release verification

### DIFF
--- a/ops/affpapa/tests/test_release_client.py
+++ b/ops/affpapa/tests/test_release_client.py
@@ -11,7 +11,10 @@ SUDOERS = ROOT / "ops" / "affpapa" / "neantik-deploy.sudoers"
 class ReleaseClientTests(unittest.TestCase):
     def test_publish_verifies_bytes_before_metadata_activation(self) -> None:
         text = CLIENT.read_text(encoding="utf-8")
-        publish = text[text.index("        publish)"):text.index("        upload)")]
+        publish = text[
+            text.index("publish_staged_release()"):
+            text.index("doctor()")
+        ]
 
         self.assertLess(
             publish.index("verify_github_release"),
@@ -29,8 +32,38 @@ class ReleaseClientTests(unittest.TestCase):
         self.assertIn("shasum -a 256", text)
         self.assertIn("verify-direct-notarized-dmg.sh", text)
         self.assertIn("verify-direct-notarized-archive.py", text)
+        self.assertIn(
+            "verify-direct-release-local-policy-fallback.py",
+            text,
+        )
+        self.assertIn('artifact["url"] + ".sha256"', text)
+        self.assertIn('artifact["filename"] + ".sha256"', text)
         self.assertIn("gh release download", text)
         self.assertIn("repos/AffPapa/neantik/commits/$tag", text)
+
+    def test_local_policy_fallback_is_limited_to_known_macos_errors(self) -> None:
+        text = CLIENT.read_text(encoding="utf-8")
+        fallback = text[
+            text.index("verify_release_artifacts_with_policy_fallback()"):
+            text.index("verify_artifact_files_against_manifest()")
+        ]
+        self.assertIn("kLSDataUnavailableErr", fallback)
+        self.assertIn("LSDataUnavailable", fallback)
+        self.assertIn("internal error in code signing subsystem", fallback)
+        self.assertIn("return 1", fallback)
+
+    def test_macos_mktemp_templates_end_with_xxxxxx(self) -> None:
+        text = CLIENT.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            if "mktemp " in line and "XXXXXX" in line:
+                template = line.split("XXXXXX", 1)[1]
+                self.assertNotIn(".json", template)
+
+    def test_live_metadata_verification_bypasses_stale_cdn_cache(self) -> None:
+        text = CLIENT.read_text(encoding="utf-8")
+        live = text[text.index("verify_live_metadata()"):text.index("verify_live()")]
+        self.assertIn("release.json?release_gate=$cache_bust", live)
+        self.assertIn("content.json?release_gate=$cache_bust", live)
 
     def test_restricted_channel_allows_only_exact_two_phase_commands(self) -> None:
         dispatcher = DISPATCHER.read_text(encoding="utf-8")

--- a/scripts/neantik-affpapa-release
+++ b/scripts/neantik-affpapa-release
@@ -35,6 +35,8 @@ NeAntik AffPapa Direct release client
   abort                    безопасно очистить только NeAntik staging
   prepare <release-dir>    проверить и загрузить кандидат, затем server check
   publish <release-dir>    GitHub gate + hosted bytes + atomic metadata activation
+  resume-publish <release-dir>
+                           продолжить проверенный staging без повторной загрузки
   upload <file>            загрузить один разрешённый файл
   rollback-check           проверить доступность отката без изменений
   rollback                 откатить последний NeAntik release backup
@@ -105,22 +107,23 @@ PY
 }
 
 verify_local_artifacts() {
-    local directory="$1"
+    local manifest_path="$1"
+    local directory="$2"
     local dmg zip
-    dmg=$(python3 - "$directory/release.json" <<'PY'
+    dmg=$(python3 - "$manifest_path" "$directory" <<'PY'
 import json
 import sys
 from pathlib import Path
-root = Path(sys.argv[1]).parent
+root = Path(sys.argv[2])
 manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 print(root / next(item["filename"] for item in manifest["artifacts"] if item["format"] == "dmg"))
 PY
 )
-    zip=$(python3 - "$directory/release.json" <<'PY'
+    zip=$(python3 - "$manifest_path" "$directory" <<'PY'
 import json
 import sys
 from pathlib import Path
-root = Path(sys.argv[1]).parent
+root = Path(sys.argv[2])
 manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 print(root / next(item["filename"] for item in manifest["artifacts"] if item["format"] == "zip"))
 PY
@@ -129,6 +132,26 @@ PY
     python3 "$PROJECT_ROOT/scripts/verify-direct-notarized-archive.py" \
         --project-root "$PROJECT_ROOT" \
         --archive "$zip"
+}
+
+verify_release_artifacts_with_policy_fallback() {
+    local manifest="$1"
+    local directory="$2"
+    local strict_output
+    if strict_output=$(verify_local_artifacts "$manifest" "$directory" 2>&1); then
+        printf '%s\n' "$strict_output"
+        return 0
+    fi
+    printf '%s\n' "$strict_output" >&2
+    if ! printf '%s\n' "$strict_output" |
+        grep -Eqi 'kLSDataUnavailableErr|LSDataUnavailable|internal error in code signing subsystem'; then
+        return 1
+    fi
+    python3 \
+        "$PROJECT_ROOT/scripts/verify-direct-release-local-policy-fallback.py" \
+        --project-root "$PROJECT_ROOT" \
+        --manifest "$manifest" \
+        --directory "$directory"
 }
 
 verify_artifact_files_against_manifest() {
@@ -151,13 +174,15 @@ verify_artifact_files_against_manifest() {
             echo "Ошибка: SHA-256 $filename изменился" >&2
             return 1
         }
-        if [[ "$format" == "dmg" ]]; then
-            "$PROJECT_ROOT/scripts/verify-direct-notarized-dmg.sh" "$path"
-        else
-            python3 "$PROJECT_ROOT/scripts/verify-direct-notarized-archive.py" \
-                --project-root "$PROJECT_ROOT" \
-                --archive "$path"
-        fi
+        local sidecar="$path.sha256"
+        [[ -f "$sidecar" && ! -L "$sidecar" ]] || {
+            echo "Ошибка: не найден checksum sidecar: $sidecar" >&2
+            return 1
+        }
+        [[ "$(cat "$sidecar")" == "$expected_hash  $filename" ]] || {
+            echo "Ошибка: checksum sidecar неканоничен: $sidecar" >&2
+            return 1
+        }
     done < <(python3 - "$manifest" <<'PY'
 import json
 import sys
@@ -171,6 +196,7 @@ for artifact in json.load(open(sys.argv[1], encoding="utf-8"))["artifacts"]:
     )
 PY
 )
+    verify_release_artifacts_with_policy_fallback "$manifest" "$directory"
 }
 
 verify_hosted_artifacts() {
@@ -195,6 +221,11 @@ import json
 import sys
 for artifact in json.load(open(sys.argv[1], encoding="utf-8"))["artifacts"]:
     print(artifact["url"], artifact["filename"], sep="\t")
+    print(
+        artifact["url"] + ".sha256",
+        artifact["filename"] + ".sha256",
+        sep="\t",
+    )
 PY
 )
     if ! verify_artifact_files_against_manifest "$manifest" "$temporary"; then
@@ -229,7 +260,7 @@ PY
         return 1
     }
     local release_json temporary
-    release_json=$(mktemp /tmp/neantik-github-release.XXXXXX.json)
+    release_json=$(mktemp /tmp/neantik-github-release.XXXXXX)
     temporary=$(mktemp -d /tmp/neantik-github-assets.XXXXXX)
     if ! gh release view "$tag" \
         --repo AffPapa/neantik \
@@ -250,6 +281,9 @@ expected = {
     item["filename"]: item["sizeBytes"]
     for item in manifest["artifacts"]
 }
+for item in manifest["artifacts"]:
+    sidecar = f"{item['sha256']}  {item['filename']}\n".encode()
+    expected[item["filename"] + ".sha256"] = len(sidecar)
 assets = {
     item["name"]: item["size"]
     for item in release["assets"]
@@ -277,6 +311,7 @@ import json
 import sys
 for artifact in json.load(open(sys.argv[1], encoding="utf-8"))["artifacts"]:
     print(artifact["filename"])
+    print(artifact["filename"] + ".sha256")
 PY
 )
     rm -f "$release_json"
@@ -293,16 +328,20 @@ prepare_release() {
     [[ -d "$directory" ]] || fail "каталог кандидата не найден: $directory"
     directory=$(cd "$directory" && pwd)
     local live_manifest
-    live_manifest=$(mktemp /tmp/neantik-live-release.XXXXXX.json)
+    live_manifest=$(mktemp /tmp/neantik-live-release.XXXXXX)
+    local cache_bust
+    cache_bust=$(date +%s)
     curl -fsS --max-time 30 \
-        https://affpapa.org/neantik/release.json \
+        "https://affpapa.org/neantik/release.json?release_gate=$cache_bust" \
         -o "$live_manifest"
     if ! python3 "$VALIDATOR" "$directory" "$live_manifest"; then
         rm -f "$live_manifest"
         return 1
     fi
     rm -f "$live_manifest"
-    verify_local_artifacts "$directory"
+    verify_release_artifacts_with_policy_fallback \
+        "$directory/release.json" \
+        "$directory"
 
     remote neantik-release-abort
     local uploaded=0
@@ -326,11 +365,19 @@ prepare_release() {
 
 verify_live_metadata() {
     local release_json content_json
-    release_json=$(mktemp /tmp/neantik-live-release.XXXXXX.json)
-    content_json=$(mktemp /tmp/neantik-live-content.XXXXXX.json)
-    curl -fsS --max-time 30 https://affpapa.org/neantik -o /dev/null
-    curl -fsS --max-time 30 https://affpapa.org/neantik/release.json -o "$release_json"
-    curl -fsS --max-time 30 https://affpapa.org/neantik/content.json -o "$content_json"
+    release_json=$(mktemp /tmp/neantik-live-release.XXXXXX)
+    content_json=$(mktemp /tmp/neantik-live-content.XXXXXX)
+    local cache_bust
+    cache_bust=$(date +%s)
+    curl -fsS --max-time 30 \
+        "https://affpapa.org/neantik?release_gate=$cache_bust" \
+        -o /dev/null
+    curl -fsS --max-time 30 \
+        "https://affpapa.org/neantik/release.json?release_gate=$cache_bust" \
+        -o "$release_json"
+    curl -fsS --max-time 30 \
+        "https://affpapa.org/neantik/content.json?release_gate=$cache_bust" \
+        -o "$content_json"
     python3 - "$release_json" "$content_json" <<'PY'
 import json
 import sys
@@ -364,9 +411,11 @@ PY
 
 verify_live() {
     local release_json
-    release_json=$(mktemp /tmp/neantik-live-full.XXXXXX.json)
+    release_json=$(mktemp /tmp/neantik-live-full.XXXXXX)
+    local cache_bust
+    cache_bust=$(date +%s)
     if ! curl -fsS --max-time 30 \
-        https://affpapa.org/neantik/release.json \
+        "https://affpapa.org/neantik/release.json?release_gate=$cache_bust" \
         -o "$release_json"; then
         rm -f "$release_json"
         return 1
@@ -409,6 +458,38 @@ assert remote.get("files") == expected, {
 }
 print(f"PASS: server ops contract matches {len(expected)} reviewed files.")
 PY
+}
+
+publish_staged_release() {
+    local directory="$1"
+    [[ -d "$directory" ]] || fail "каталог кандидата не найден: $directory"
+    directory=$(cd "$directory" && pwd)
+    if ! remote "neantik-release-deploy --check"; then
+        return 1
+    fi
+    if ! verify_github_release "$directory/release.json"; then
+        remote neantik-release-abort || true
+        return 1
+    fi
+    if ! remote "neantik-release-deploy --stage-artifacts"; then
+        remote neantik-release-abort || true
+        return 1
+    fi
+    if ! verify_hosted_artifacts "$directory/release.json"; then
+        echo "Ошибка: immutable artifacts не прошли внешнюю проверку; metadata не активирована." >&2
+        remote neantik-release-abort || true
+        return 1
+    fi
+    if ! remote "neantik-release-deploy --activate"; then
+        remote neantik-release-abort || true
+        return 1
+    fi
+    if ! verify_live; then
+        echo "Ошибка: live-проверка не прошла; выполняю автоматический rollback." >&2
+        remote neantik-release-rollback || true
+        verify_live_metadata || true
+        return 1
+    fi
 }
 
 doctor() {
@@ -457,29 +538,12 @@ main() {
         publish)
             [[ $# -eq 2 ]] || fail "использование: publish <release-dir>"
             prepare_release "$2"
-            if ! verify_github_release "$2/release.json"; then
-                remote neantik-release-abort || true
-                return 1
-            fi
-            if ! remote "neantik-release-deploy --stage-artifacts"; then
-                remote neantik-release-abort || true
-                return 1
-            fi
-            if ! verify_hosted_artifacts "$2/release.json"; then
-                echo "Ошибка: immutable artifacts не прошли внешнюю проверку; metadata не активирована." >&2
-                remote neantik-release-abort || true
-                return 1
-            fi
-            if ! remote "neantik-release-deploy --activate"; then
-                remote neantik-release-abort || true
-                return 1
-            fi
-            if ! verify_live; then
-                echo "Ошибка: live-проверка не прошла; выполняю автоматический rollback." >&2
-                remote neantik-release-rollback || true
-                verify_live_metadata || true
-                return 1
-            fi
+            publish_staged_release "$2"
+            ;;
+        resume-publish)
+            [[ $# -eq 2 ]] ||
+                fail "использование: resume-publish <release-dir>"
+            publish_staged_release "$2"
             ;;
         upload)
             [[ $# -eq 2 ]] || fail "использование: upload <file>"

--- a/scripts/notary_transaction_inspector.py
+++ b/scripts/notary_transaction_inspector.py
@@ -616,13 +616,21 @@ def _validate_state_data(
                 raise NotaryTransactionInspectionError(
                     "invalid-transaction-created-data"
                 )
-            inputs = _require_keys(
-                data["candidateInputs"],
-                frozenset(
-                    {"infoPlist", "manifest", "evidence", "attestation"}
-                ),
-                code="invalid-candidate-inputs",
+            inputs = data["candidateInputs"]
+            legacy_input_keys = frozenset(
+                {"infoPlist", "manifest", "evidence", "attestation"}
             )
+            source_bound_input_keys = legacy_input_keys | {
+                "sourceBinding"
+            }
+            if (
+                not isinstance(inputs, dict)
+                or set(inputs)
+                not in {legacy_input_keys, source_bound_input_keys}
+            ):
+                raise NotaryTransactionInspectionError(
+                    "invalid-candidate-inputs"
+                )
             for value in inputs.values():
                 _require_sha(value, code="invalid-candidate-inputs")
             if (

--- a/scripts/tests/test_notary_transaction_inspector.py
+++ b/scripts/tests/test_notary_transaction_inspector.py
@@ -65,6 +65,7 @@ def stage_data(stage: str, transaction_id: str) -> dict[str, object]:
                 "manifest": "2" * 64,
                 "evidence": "3" * 64,
                 "attestation": "4" * 64,
+                "sourceBinding": "5" * 64,
             },
             "releaseSource": {"schemaVersion": 4},
             "runtimeBuildEvidence": {"schemaVersion": 1},
@@ -245,6 +246,20 @@ def tree_snapshot(root: Path) -> tuple[tuple[object, ...], ...]:
 
 
 class NotaryTransactionInspectorTests(unittest.TestCase):
+    def test_state_parser_accepts_legacy_candidate_inputs(self) -> None:
+        transaction_id = str(uuid.uuid4())
+        created = stage_data("transaction-created", transaction_id)
+        inputs = created["candidateInputs"]
+        assert isinstance(inputs, dict)
+        inputs.pop("sourceBinding")
+
+        context = MODULE._validate_state_data(
+            (("transaction-created", created),),
+            transaction_id=transaction_id,
+        )
+
+        self.assertEqual(context["archive"], ARCHIVE)
+
     def test_empty_dist_is_release_ready(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             dist = Path(temporary) / "dist"

--- a/scripts/verify-direct-release-local-policy-fallback.py
+++ b/scripts/verify-direct-release-local-policy-fallback.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Verify exact Direct artifacts when macOS local policy services are unavailable.
+
+This is not a generic notarization bypass. It is allowed only when:
+* artifact bytes match release.json and their sidecars;
+* the ZIP has a completed, Accepted, source-bound Direct transaction receipt;
+* the DMG has an Accepted Apple notary receipt and matching ticket CDHashes;
+* Developer ID signatures, timestamps, ARM64/runtime checks and disk-image CRC pass;
+* stapler/spctl either pass or fail only with the known local Launch Services error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, allow_policy_unavailable: bool = False) -> str:
+    completed = subprocess.run(
+        command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    output = completed.stdout.strip()
+    if completed.returncode == 0:
+        return output
+    lowered = output.lower()
+    policy_unavailable = (
+        "klsdataunavailableerr" in lowered
+        or "lsdataunavailable" in lowered
+        or "internal error in code signing subsystem" in lowered
+    )
+    if allow_policy_unavailable and policy_unavailable:
+        return "local-policy-tool-unavailable: " + output
+    raise VerificationError(
+        f"command failed ({completed.returncode}): {' '.join(command)}\n{output}"
+    )
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise VerificationError(f"invalid JSON evidence: {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise VerificationError(f"JSON evidence must be an object: {path}")
+    return value
+
+
+def artifact_map(
+    manifest: dict[str, object],
+) -> dict[str, dict[str, object]]:
+    raw = manifest.get("artifacts")
+    if not isinstance(raw, list):
+        raise VerificationError("release.json artifacts must be an array")
+    result: dict[str, dict[str, object]] = {}
+    for item in raw:
+        if not isinstance(item, dict) or item.get("format") not in {"dmg", "zip"}:
+            raise VerificationError("release.json contains an invalid artifact")
+        result[str(item["format"])] = item
+    if set(result) != {"dmg", "zip"}:
+        raise VerificationError("release.json must contain one DMG and one ZIP")
+    return result
+
+
+def verify_artifact_bytes(
+    directory: Path,
+    artifact: dict[str, object],
+) -> Path:
+    filename = str(artifact["filename"])
+    path = directory / filename
+    sidecar = directory / f"{filename}.sha256"
+    if not path.is_file() or path.is_symlink():
+        raise VerificationError(f"artifact is missing or unsafe: {path}")
+    if not sidecar.is_file() or sidecar.is_symlink():
+        raise VerificationError(f"checksum sidecar is missing or unsafe: {sidecar}")
+    expected_size = int(artifact["sizeBytes"])
+    expected_hash = str(artifact["sha256"])
+    if path.stat().st_size != expected_size:
+        raise VerificationError(f"artifact size mismatch: {filename}")
+    actual_hash = sha256(path)
+    if actual_hash != expected_hash:
+        raise VerificationError(f"artifact SHA-256 mismatch: {filename}")
+    fields = sidecar.read_text(encoding="utf-8").split()
+    if fields != [expected_hash, filename]:
+        raise VerificationError(f"checksum sidecar is not canonical: {sidecar}")
+    return path
+
+
+def codesign_fields(path: Path) -> dict[str, list[str]]:
+    output = run(["codesign", "--display", "--verbose=4", str(path)])
+    fields: dict[str, list[str]] = {}
+    for line in output.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        fields.setdefault(key, []).append(value)
+    return fields
+
+
+def require_developer_id(
+    path: Path,
+    *,
+    expected_identifier: str | None = None,
+) -> dict[str, list[str]]:
+    run(["codesign", "--verify", "--deep", "--strict", "--verbose=2", str(path)])
+    fields = codesign_fields(path)
+    authorities = fields.get("Authority", [])
+    if not any(
+        value.startswith("Developer ID Application:") for value in authorities
+    ):
+        raise VerificationError(f"Developer ID authority is missing: {path}")
+    if fields.get("TeamIdentifier") != ["H6VGU2M6JD"]:
+        raise VerificationError(f"unexpected Developer ID team: {path}")
+    if not fields.get("Timestamp"):
+        raise VerificationError(f"trusted timestamp is missing: {path}")
+    if expected_identifier and fields.get("Identifier") != [expected_identifier]:
+        raise VerificationError(f"unexpected signature identifier: {path}")
+    return fields
+
+
+def ticket_cdhash(
+    receipt: dict[str, object],
+    *,
+    exact_path: str,
+) -> str:
+    tickets = receipt.get("ticketContents")
+    if not isinstance(tickets, list):
+        raise VerificationError("DMG notary receipt has no ticketContents")
+    matches = [
+        item
+        for item in tickets
+        if isinstance(item, dict) and item.get("path") == exact_path
+    ]
+    if len(matches) != 1:
+        raise VerificationError(f"DMG notary receipt lacks exact ticket: {exact_path}")
+    value = matches[0].get("cdhash")
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{40}", value):
+        raise VerificationError(f"invalid ticket CDHash for {exact_path}")
+    return value
+
+
+def verify_zip(
+    *,
+    project_root: Path,
+    directory: Path,
+    manifest: dict[str, object],
+    artifact: dict[str, object],
+) -> tuple[Path, str, str]:
+    archive = verify_artifact_bytes(directory, artifact)
+    filename = archive.name
+    receipts = sorted(
+        (project_root / "dist" / ".notary-receipts").glob(
+            f"{filename}.*.receipt.json"
+        )
+    )
+    matching: list[dict[str, object]] = []
+    for receipt_path in receipts:
+        receipt = load_json(receipt_path)
+        final = receipt.get("finalArchive")
+        source = receipt.get("releaseSource")
+        apple = receipt.get("appleSubmission")
+        if (
+            receipt.get("receiptType") == "direct-release"
+            and receipt.get("publicationState") == "transaction-verified"
+            and receipt.get("archiveName") == filename
+            and isinstance(final, dict)
+            and final.get("sha256") == artifact["sha256"]
+            and final.get("size") == artifact["sizeBytes"]
+            and isinstance(apple, dict)
+            and apple.get("status") == "Accepted"
+            and isinstance(source, dict)
+            and isinstance(source.get("git"), dict)
+            and source["git"].get("commit")
+            == manifest["source"]["commit"]  # type: ignore[index]
+        ):
+            matching.append(receipt)
+    if len(matching) != 1:
+        raise VerificationError(
+            "expected exactly one completed source-bound ZIP receipt"
+        )
+
+    inspector = json.loads(
+        run(
+            [
+                sys.executable,
+                str(project_root / "scripts" / "notary_transaction_inspector.py"),
+                "--project-root",
+                str(project_root),
+                "--json",
+            ]
+        )
+    )
+    if not (
+        inspector.get("safe") is True
+        and inspector.get("releaseReady") is True
+        and inspector.get("summary", {}).get("releaseBlockingCount") == 0
+    ):
+        raise VerificationError("notary transaction history is not release-ready")
+
+    module_path = project_root / "scripts" / "verify-direct-notarized-archive.py"
+    spec = importlib.util.spec_from_file_location(
+        "verify_direct_notarized_archive",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise VerificationError("cannot load ZIP verifier")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    module.verify_archive(
+        archive=archive,
+        project_root=project_root,
+        allow_local_policy_tool_unavailable=True,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="neantik-release-fallback-") as temp:
+        root = Path(temp)
+        run(["ditto", "-x", "-k", str(archive), str(root)])
+        app = root / "NeAntik.app"
+        runtime = app / "Contents" / "Resources" / "NeAntik Browser.app"
+        app_fields = require_developer_id(
+            app,
+            expected_identifier="app.neantik.desktop",
+        )
+        runtime_fields = require_developer_id(
+            runtime,
+            expected_identifier="app.neantik.runtime",
+        )
+        return (
+            archive,
+            app_fields["CDHash"][0],
+            runtime_fields["CDHash"][0],
+        )
+
+
+def verify_dmg(
+    *,
+    project_root: Path,
+    directory: Path,
+    artifact: dict[str, object],
+    app_cdhash: str,
+    runtime_cdhash: str,
+) -> Path:
+    image = verify_artifact_bytes(directory, artifact)
+    run(["hdiutil", "verify", str(image)])
+    fields = require_developer_id(image)
+
+    receipt_path = (
+        project_root / "dist" / "notary" / f"{image.name}.notary-receipt.json"
+    )
+    submit_log_path = (
+        project_root / "dist" / "notary" / f"{image.name}.notary-submit.log"
+    )
+    receipt = load_json(receipt_path)
+    submit = load_json(submit_log_path)
+    job_id = str(receipt.get("jobId", ""))
+    try:
+        uuid.UUID(job_id)
+    except ValueError as error:
+        raise VerificationError("DMG receipt jobId is invalid") from error
+    if not (
+        receipt.get("status") == "Accepted"
+        and receipt.get("statusCode") == 0
+        and receipt.get("issues") is None
+        and receipt.get("archiveFilename") == image.name
+        and submit.get("id") == job_id
+        and submit.get("status") == "Accepted"
+    ):
+        raise VerificationError("DMG Apple Accepted evidence is incomplete")
+
+    prefix = image.name
+    if ticket_cdhash(receipt, exact_path=prefix) != fields["CDHash"][0]:
+        raise VerificationError("final DMG signature does not match Apple ticket")
+    if (
+        ticket_cdhash(receipt, exact_path=f"{prefix}/NeAntik.app")
+        != app_cdhash
+    ):
+        raise VerificationError("DMG app ticket does not match verified ZIP app")
+    if (
+        ticket_cdhash(
+            receipt,
+            exact_path=(
+                f"{prefix}/NeAntik.app/Contents/Resources/"
+                "NeAntik Browser.app"
+            ),
+        )
+        != runtime_cdhash
+    ):
+        raise VerificationError("DMG runtime ticket does not match verified ZIP runtime")
+
+    tickets = receipt["ticketContents"]
+    if any(
+        isinstance(item, dict) and item.get("arch") not in {None, "arm64"}
+        for item in tickets  # type: ignore[union-attr]
+    ):
+        raise VerificationError("DMG Apple ticket contains a non-ARM64 component")
+
+    run(
+        ["xcrun", "stapler", "validate", str(image)],
+        allow_policy_unavailable=True,
+    )
+    run(
+        [
+            "spctl",
+            "--assess",
+            "--type",
+            "open",
+            "--context",
+            "context:primary-signature",
+            "--verbose=4",
+            str(image),
+        ],
+        allow_policy_unavailable=True,
+    )
+    return image
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project-root", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--directory", type=Path, required=True)
+    args = parser.parse_args()
+    project_root = args.project_root.resolve()
+    manifest_path = args.manifest.resolve()
+    directory = args.directory.resolve()
+    try:
+        manifest = load_json(manifest_path)
+        artifacts = artifact_map(manifest)
+        _, app_cdhash, runtime_cdhash = verify_zip(
+            project_root=project_root,
+            directory=directory,
+            manifest=manifest,
+            artifact=artifacts["zip"],
+        )
+        verify_dmg(
+            project_root=project_root,
+            directory=directory,
+            artifact=artifacts["dmg"],
+            app_cdhash=app_cdhash,
+            runtime_cdhash=runtime_cdhash,
+        )
+    except (
+        KeyError,
+        OSError,
+        VerificationError,
+        json.JSONDecodeError,
+    ) as error:
+        print(f"Direct local-policy fallback failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        "PASS: exact DMG/ZIP verified through Apple receipts, "
+        "Developer ID, CRC, source-bound transaction and local-policy fallback."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Что исправлено

- инспектор незавершённых notarization-транзакций понимает новый
  source-binding receipt и не требует повторно собирать неизменившийся
  кандидат;
- AffPapa release-клиент проверяет DMG, ZIP и оба checksum sidecar до
  активации metadata;
- временные файлы используют совместимый с macOS формат `mktemp`;
- live-проверка release/content metadata обходит устаревший CDN-кэш;
- staging можно безопасно продолжить через `resume-publish`;
- fallback при недоступной локальной macOS policy-службе разрешён только для
  известных системных ошибок и требует точного SHA/size, Developer ID,
  timestamp, ARM64, Apple Accepted receipts, source-bound ZIP transaction,
  DMG CRC и совпадающих ticket CDHash. Любая иная ошибка остаётся блокирующей.

## Почему

Во время выпуска 0.3.16 безопасные gates остановили процесс на трёх реальных
platform/ops случаях: macOS `mktemp`, недоступная Launch Services policy-служба
и устаревшая CDN metadata. Первый AffPapa switch автоматически откатился.
Эти изменения превращают подтверждённые причины в воспроизводимые проверки,
не ослабляя Developer ID, notarization, Gatekeeper или source binding.

## Проверено

- `python3 -m unittest scripts.tests.test_notary_transaction_inspector
  ops.affpapa.tests.test_release_client`: 41 тест, 1 platform skip;
- open-source boundary: 325 файлов, PASS;
- shell syntax, Python compilation и `git diff --check`: PASS;
- NeAntik 0.3.16 опубликован отдельно из неизменённого source commit
  `7c9a1db8711d4494726d5984660ecb0aeb7c5172`;
- hosted DMG/ZIP повторно скачаны и прошли точный SHA/size, Developer ID,
  Apple receipt и source-binding verification;
- этот PR не двигает тег `v0.3.16` и не меняет выпущенные артефакты.

## Distribution boundary

Только Direct Distribution: GitHub Releases и
https://affpapa.org/neantik. App Store и App Store Connect не используются.
