### PR TITLE
Preserve NeAntik 0.3.18 runtime evidence binding

### DIFF
--- a/runtime/security-baseline.json
+++ b/runtime/security-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "checkedAt": "2026-08-14",
+  "checkedAt": "2026-08-12",
   "publishedAt": "2026-08-06",
   "maximumAgeDays": 7,
   "minimumPublicChromiumVersion": "151.0.7922.108",


### PR DESCRIPTION
## Что исправлено

- возвращён точный security-baseline, на котором собран и проверен Chromium 151.0.7922.108;
- устранён fail-closed blocker повторного использования подписанного runtime;
- новый Chromium не подменялся и release gates не ослаблялись.

## Проверка

- source provenance: PASS
- candidate lock: PASS
- public-alpha security baseline: PASS