### PR TITLE
Fix macOS 27 Chromium LINKEDIT layout

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -69,7 +69,10 @@ Running without a phase performs the complete sequence. The wrapper:
   once;
 - verifies exact postimage hashes from the owned manifest;
 - emits source provenance and an immutable candidate lock;
-- configures an official ARM64 build with Metal and `symbol_level=0`;
+- configures an official ARM64 build with Metal, `symbol_level=0`, and
+  `enable_stripping=false`; the last setting preserves the linker's valid
+  pointer-aligned Mach-O layout instead of passing it through the LLVM 22
+  post-link strip path rejected by macOS 27 dyld;
 - keeps `chrome_pgo_phase=0`, matching the verified public runtime, because
   the pinned official lite archive does not carry the macOS PGO profile and
   the release pipeline never downloads an unpinned optimization input;

--- a/runtime/chromium-152-source-contract.json
+++ b/runtime/chromium-152-source-contract.json
@@ -58,7 +58,7 @@
     "runtime/apple-device-tuples.json": "3c355a6a6708386c410c98cb9310a6f6e62ea5da065eb0faf0290b2a4a4ff6f2",
     "scripts/apply-owned-runtime-device-tuples.py": "75bb4a1d32d1dc82763200f32905783c9ca5e86033bf2314dca071dc47522ecc",
     "runtime/chromium-152-toolchain-lock.json": "1bd134675b33ce24661a0210c98d5a6dc3a6fb565b484b39940f2b22de861932",
-    "scripts/build-runtime.sh": "48993f714970aa99d00432a9a27805daf09d1994de3a94fde99321f59b5d3ff9",
+    "scripts/build-runtime.sh": "cb5e9a08606443ee81f63d592ab2bff7dcfd2122e22543bfe9eafc7ebfc53b02",
     "scripts/prepare-runtime-source.sh": "c982e14d1309ae0dd229fffa3b2cf02821a2c7fc2d4d717f95dff40a7e784399",
     "scripts/verify-runtime-source-pair.py": "f5861af3abc545d20f86066bed24b11152812fae1865eeb3d79ea7c27d8c6d57",
     "scripts/verify-chromium-webrtc-policy.py": "7a307f5e77fb6e2e8aad3319272da657d83cae01a6441f6c57e7707d4dc4f970",

--- a/scripts/build-runtime.sh
+++ b/scripts/build-runtime.sh
@@ -638,6 +638,12 @@ configure_build() {
     > "$SOURCE_DIR/out/Default/args.gn"
   printf '%s\n' 'target_cpu = "arm64"' \
     >> "$SOURCE_DIR/out/Default/args.gn"
+  # llvm-strip 22 can move a 64-bit Mach-O string table off pointer-size
+  # alignment. macOS 27 dyld rejects the resulting dylib before Chromium can
+  # start. symbol_level=0 already omits debug symbols from this shipping build,
+  # so keep the linker's valid output instead of post-processing it.
+  printf '%s\n' 'enable_stripping=false' \
+    >> "$SOURCE_DIR/out/Default/args.gn"
   if [[ "${NEANTIK_NO_METAL:-0}" == "1" ]]; then
     printf '%s\n' 'angle_enable_metal = false' \
       >> "$SOURCE_DIR/out/Default/args.gn"
@@ -685,6 +691,7 @@ configure_build() {
   printf '%s\n' \
     "architecture=arm64" \
     "symbol_level=0" \
+    "stripping=disabled" \
     "no_metal=${NEANTIK_NO_METAL:-0}" \
     "metal_toolchain=${NEANTIK_METAL_TOOLCHAIN_PATH:-system-xcrun}" \
     "gn=generated" \

--- a/scripts/tests/test_build_runtime_script.py
+++ b/scripts/tests/test_build_runtime_script.py
@@ -118,6 +118,14 @@ class BuildRuntimeScriptTests(unittest.TestCase):
         self.assertIn('print "chrome_pgo_phase=0"', script)
         self.assertIn("pgo_written", script)
 
+    def test_shipping_build_avoids_macos27_llvm_strip_corruption(self) -> None:
+        script = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn("llvm-strip 22", script)
+        self.assertIn("macOS 27 dyld", script)
+        self.assertIn("'enable_stripping=false'", script)
+        self.assertIn('"stripping=disabled"', script)
+
     def test_go_generators_keep_cache_inside_build_root(self) -> None:
         script = SCRIPT.read_text(encoding="utf-8")
 

--- a/scripts/tests/test_verify_built_runtime_script.py
+++ b/scripts/tests/test_verify_built_runtime_script.py
@@ -123,6 +123,17 @@ class VerifyBuiltRuntimeScriptTests(unittest.TestCase):
         )
         self.assertNotIn("for protocol_string in", script)
 
+    def test_rejects_misaligned_macho_linkedit_string_tables(self) -> None:
+        script = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn('otool -l "$binary"', script)
+        self.assertIn('LC_SYMTAB', script)
+        self.assertIn('string_table_offset % 8 != 0', script)
+        self.assertIn(
+            "Misaligned 64-bit Mach-O LINKEDIT string table",
+            script,
+        )
+
     def test_public_contract_does_not_document_legacy_private_argv(self) -> None:
         contract = (
             PROJECT_ROOT / "docs" / "FINGERPRINT_RUNTIME.md"

--- a/scripts/verify-built-runtime.sh
+++ b/scripts/verify-built-runtime.sh
@@ -206,6 +206,21 @@ while IFS= read -r binary; do
     echo "Non-ARM64 nested code: $binary ($architectures)" >&2
     exit 65
   fi
+  string_table_offset="$(
+    otool -l "$binary" |
+      awk '
+        $1 == "cmd" && $2 == "LC_SYMTAB" { in_symtab = 1; next }
+        in_symtab && $1 == "cmd" { exit }
+        in_symtab && $1 == "stroff" { print $2; exit }
+      '
+  )"
+  if [[ -n "$string_table_offset" ]] &&
+      (( string_table_offset % 8 != 0 )); then
+    echo \
+      "Misaligned 64-bit Mach-O LINKEDIT string table: $binary ($string_table_offset)" \
+      >&2
+    exit 65
+  fi
 done < "$MACHO_LIST"
 
 if (( MACHO_COUNT == 0 )); then


### PR DESCRIPTION
## Summary
- keep the Chromium 152 shipping build at `symbol_level=0` while disabling LLVM 22 post-link stripping
- fail closed if any packaged ARM64 Mach-O has a misaligned `LC_SYMTAB` string table
- bind the build-script change into the owned Chromium source contract

## Evidence
- reproduced `mis-aligned LINKEDIT string pool` at offset `0x0FB7515C` on the source-built framework
- targeted build/verifier tests: 22 passed
- runtime source-provenance tests: 10 passed
- exact owned Chromium source pair verified

Public distribution remains `0.3.19 (22)` until the complete signed and notarized candidate passes.