### PR TITLE
Fix Direct release audit app-bundle binding

### DIFF
--- a/Sources/NeAntik/LaunchIntent.swift
+++ b/Sources/NeAntik/LaunchIntent.swift
@@ -34,6 +34,27 @@ struct NeAntikLaunchIntent: Equatable, Sendable {
         return nil
     }
 
+    static func applicationBundleURL(
+        forExecutablePath path: String
+    ) -> URL? {
+        guard isCanonicalAbsoluteExecutablePath(path) else {
+            return nil
+        }
+        let executableURL = URL(fileURLWithPath: path)
+        let bundleURL = executableURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        guard bundleURL.pathExtension == "app",
+              bundleURL.appendingPathComponent(
+                  "Contents/MacOS/NeAntik"
+              ).path == path
+        else {
+            return nil
+        }
+        return bundleURL
+    }
+
     static func parse(arguments: [String]) -> Self {
         if arguments.count == 4,
            isCanonicalAbsoluteExecutablePath(arguments[0]),

--- a/Sources/NeAntik/NeAntikApp.swift
+++ b/Sources/NeAntik/NeAntikApp.swift
@@ -46,12 +46,23 @@ struct NeAntikApp: App {
             self.launchIntent = launchIntent
             if let request {
                 do {
+                    let executableURL = URL(
+                        fileURLWithPath: CommandLine.arguments[0]
+                    )
+                    guard let bundleURL =
+                            NeAntikLaunchIntent.applicationBundleURL(
+                                forExecutablePath:
+                                    CommandLine.arguments[0]
+                            ),
+                          let releaseBundle = Bundle(url: bundleURL)
+                    else {
+                        throw FingerprintEvidenceReleaseError
+                            .candidateMetadataMismatch
+                    }
                     switch try FingerprintEvidenceReleaseContext.load(
                             request: request,
-                            executableURL: URL(
-                                fileURLWithPath:
-                                    CommandLine.arguments[0]
-                            )
+                            executableURL: executableURL,
+                            bundle: releaseBundle
                         ) {
                     case let .audit(context):
                         fingerprintEvidenceReleaseContext = context
@@ -60,7 +71,8 @@ struct NeAntikApp: App {
                     }
                 } catch {
                     Self.writeControlErrorAndExit(
-                        "Не удалось подготовить защищённую проверку выпуска.\n",
+                        "Не удалось подготовить защищённую проверку выпуска: " +
+                            error.localizedDescription + "\n",
                         code: EX_DATAERR
                     )
                 }

--- a/Tests/NeAntikTests/LaunchIntentTests.swift
+++ b/Tests/NeAntikTests/LaunchIntentTests.swift
@@ -44,6 +44,30 @@ struct LaunchIntentTests {
     }
 
     @Test
+    func releaseExecutableResolvesItsOwningApplicationBundle() {
+        let executable =
+            "/Applications/NeAntik.app/Contents/MacOS/NeAntik"
+
+        #expect(
+            NeAntikLaunchIntent.applicationBundleURL(
+                forExecutablePath: executable
+            )?.path == "/Applications/NeAntik.app"
+        )
+        #expect(
+            NeAntikLaunchIntent.applicationBundleURL(
+                forExecutablePath:
+                    "/Applications/NeAntik.app/Contents/MacOS/Other"
+            ) == nil
+        )
+        #expect(
+            NeAntikLaunchIntent.applicationBundleURL(
+                forExecutablePath:
+                    "relative/NeAntik.app/Contents/MacOS/NeAntik"
+            ) == nil
+        )
+    }
+
+    @Test
     func similarReservedArgumentFailsClosed() {
         let intent = NeAntikLaunchIntent.parse(
             arguments: [


### PR DESCRIPTION
## Причина

Единственный Direct release attempt для 0.3.20 fail-closed завершился до browser audit и до Apple notarization: при прямом запуске `Contents/MacOS/NeAntik` процесс не должен полагаться на `Bundle.main` для привязки version/build.

## Исправление

- bundle разрешается только из канонического `.../NeAntik.app/Contents/MacOS/NeAntik`;
- любое другое расположение остаётся fail-closed;
- stderr теперь сообщает безопасный localized error без секретов;
- добавлена регрессия `LaunchIntentTests`.

## Проверка

- `./scripts/verify-native-swift-suite.sh LaunchIntentTests`: 7/7 PASS;
- прежний candidate не нотарифицировался и ничего публичного не менял;
- Chromium source/runtime не изменены.