### PR TITLE
Fix Direct packaging to use current Swift binary

### DIFF
--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -30,9 +30,25 @@ swift build \
   --config-path "$BUILD_SUPPORT_DIR/config" \
   --security-path "$BUILD_SUPPORT_DIR/security"
 
+BIN_PATH="$(
+  swift build \
+    -c release \
+    --arch arm64 \
+    --disable-sandbox \
+    --cache-path "$BUILD_SUPPORT_DIR/cache" \
+    --config-path "$BUILD_SUPPORT_DIR/config" \
+    --security-path "$BUILD_SUPPORT_DIR/security" \
+    --show-bin-path
+)"
+MANAGER_BINARY="$BIN_PATH/NeAntik"
+if [[ ! -x "$MANAGER_BINARY" ]]; then
+  echo "Swift release binary is missing: $MANAGER_BINARY" >&2
+  exit 70
+fi
+
 rm -rf "$APP_DIR"
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
-cp "$PROJECT_DIR/.build/arm64-apple-macosx/release/NeAntik" "$MACOS_DIR/NeAntik"
+cp "$MANAGER_BINARY" "$MACOS_DIR/NeAntik"
 
 cp "$PROJECT_DIR/Resources/Info.plist" "$CONTENTS_DIR/Info.plist"
 printf 'APPLNANT' >"$CONTENTS_DIR/PkgInfo"

--- a/scripts/prepare-direct-manager-update.sh
+++ b/scripts/prepare-direct-manager-update.sh
@@ -184,10 +184,25 @@ swift build \
   --config-path "$BUILD_SUPPORT_DIR/config" \
   --security-path "$BUILD_SUPPORT_DIR/security"
 
+BIN_PATH="$(
+  swift build \
+    -c release \
+    --arch arm64 \
+    --disable-sandbox \
+    --cache-path "$BUILD_SUPPORT_DIR/cache" \
+    --config-path "$BUILD_SUPPORT_DIR/config" \
+    --security-path "$BUILD_SUPPORT_DIR/security" \
+    --show-bin-path
+)"
+MANAGER_BINARY="$BIN_PATH/NeAntik"
+if [[ ! -x "$MANAGER_BINARY" ]]; then
+  echo "Swift release binary is missing: $MANAGER_BINARY" >&2
+  exit 70
+fi
+
 rm -rf "$CANDIDATE_APP"
 ditto --norsrc "$SOURCE_APP" "$CANDIDATE_APP"
-cp "$PROJECT_DIR/.build/arm64-apple-macosx/release/NeAntik" \
-  "$CANDIDATE_APP/Contents/MacOS/NeAntik"
+cp "$MANAGER_BINARY" "$CANDIDATE_APP/Contents/MacOS/NeAntik"
 cp "$PROJECT_DIR/Resources/Info.plist" \
   "$CANDIDATE_APP/Contents/Info.plist"
 cp "$PROJECT_DIR/Resources/NeAntik.icns" \

--- a/scripts/tests/test_release_direct_script.py
+++ b/scripts/tests/test_release_direct_script.py
@@ -5,6 +5,7 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parents[1]
 PREPARE = SCRIPTS / "prepare-direct-runtime-candidate.sh"
 PREPARE_MANAGER = SCRIPTS / "prepare-direct-manager-update.sh"
+PACKAGE_APP = SCRIPTS / "package-app.sh"
 RELEASE = SCRIPTS / "release-direct.sh"
 NOTARIZE = SCRIPTS / "notarize-direct-candidate.sh"
 NOTARY_TRANSACTION = SCRIPTS / "notarize_direct_transaction.py"
@@ -13,6 +14,16 @@ INTEGRATED_VERIFIER = SCRIPTS / "verify-integrated-release.sh"
 
 
 class ReleaseDirectScriptTests(unittest.TestCase):
+    def test_release_packaging_resolves_current_swift_bin_path(self) -> None:
+        stale_path = ".build/arm64-apple-macosx/release/NeAntik"
+
+        for script in (PACKAGE_APP, PREPARE_MANAGER):
+            text = script.read_text(encoding="utf-8")
+            self.assertIn("--show-bin-path", text)
+            self.assertIn('MANAGER_BINARY="$BIN_PATH/NeAntik"', text)
+            self.assertIn('cp "$MANAGER_BINARY"', text)
+            self.assertNotIn(stale_path, text)
+
     def test_prepare_builds_and_binds_one_exact_candidate(self) -> None:
         text = PREPARE.read_text(encoding="utf-8")
         self.assertIn('CANDIDATE_LOCK="$4"', text)


### PR DESCRIPTION
## Root cause

The current SwiftPM/Xcode layout reports `.build/release` through `--show-bin-path`. `package-app.sh` and `prepare-direct-manager-update.sh` still copied a stale fixed `.build/arm64-apple-macosx/release/NeAntik` left from August 14. This made a new source binding package an old manager executable, so the release audit correctly failed closed before Chromium and before notarization.

## Fix

- resolve the exact release output with the same `swift build --show-bin-path` arguments;
- require the resolved manager binary to exist and be executable;
- copy only that binary in both packaging paths;
- add a regression that rejects the stale fixed path.

## Evidence

- shell syntax PASS;
- targeted Python regression PASS;
- local ad-hoc package contains the new release-audit diagnostic string;
- no Chromium source/runtime or public release state changed;
- Apple notarization was never submitted for the failed candidate.