### PR TITLE
Harden Direct release preflight and evidence recovery

### DIFF
--- a/scripts/Run-NeAntik-Release.command
+++ b/scripts/Run-NeAntik-Release.command
@@ -224,6 +224,38 @@ for EXISTING_SCHEMA8_SOURCE in \
   fi
 done
 
+verify_current_gui_attempt_evidence() {
+  python3 "$PROJECT_DIR/scripts/collect-gui-fingerprint-evidence.py" \
+    --source "$SCHEMA8_SOURCE" \
+    --integrated-app "$APP_PATH" \
+    --candidate-manifest "$CANDIDATE_MANIFEST" \
+    --release-channel "$NEANTIK_RELEASE_CHANNEL" \
+    --not-before "$GUI_NOT_BEFORE" \
+    --output "$REPORT_PATH"
+}
+
+evaluate_current_gui_attempt() {
+  if (( GUI_TIMED_OUT == 0 && GUI_EXIT_STATUS != 0 )); then
+    echo "NeAntik завершил автоматическую проверку с кодом $GUI_EXIT_STATUS." >&2
+    echo "Notarization не запускалась." >&2
+    return 66
+  fi
+
+  if verify_current_gui_attempt_evidence; then
+    if (( GUI_TIMED_OUT != 0 )); then
+      echo
+      echo "PASS: GUI превысил timeout, но успел сохранить свежий проверенный отчёт для этого точного кандидата."
+    fi
+    return 0
+  fi
+
+  if (( GUI_TIMED_OUT != 0 )); then
+    echo "После timeout не найден свежий валидный отчёт этого GUI-attempt; notarization не запускалась." >&2
+    return 67
+  fi
+  return 1
+}
+
 attempt=1
 while (( REUSED_GUI_EVIDENCE == 0 && attempt <= 3 )); do
   python3 "$PROJECT_DIR/scripts/wait-for-neantik-runtime-drain.py" \
@@ -271,25 +303,16 @@ while (( REUSED_GUI_EVIDENCE == 0 && attempt <= 3 )); do
   wait "$GUI_PID" >/dev/null 2>&1 || GUI_EXIT_STATUS="$?"
   python3 "$PROJECT_DIR/scripts/wait-for-neantik-runtime-drain.py" \
     --app "$APP_PATH"
-  if (( GUI_TIMED_OUT != 0 )); then
-    echo "Повторная попытка после timeout запрещена; notarization не запускалась." >&2
-    exit 67
-  fi
-  if (( GUI_EXIT_STATUS != 0 )); then
-    echo "NeAntik завершил автоматическую проверку с кодом $GUI_EXIT_STATUS." >&2
-    echo "Notarization не запускалась." >&2
-    exit 66
-  fi
-
-  if python3 "$PROJECT_DIR/scripts/collect-gui-fingerprint-evidence.py" \
-    --source "$SCHEMA8_SOURCE" \
-    --integrated-app "$APP_PATH" \
-    --candidate-manifest "$CANDIDATE_MANIFEST" \
-    --release-channel "$NEANTIK_RELEASE_CHANNEL" \
-    --not-before "$GUI_NOT_BEFORE" \
-    --output "$REPORT_PATH"; then
-    break
-  fi
+  GUI_ATTEMPT_STATUS=0
+  evaluate_current_gui_attempt || GUI_ATTEMPT_STATUS="$?"
+  case "$GUI_ATTEMPT_STATUS" in
+    0)
+      break
+      ;;
+    66|67)
+      exit "$GUI_ATTEMPT_STATUS"
+      ;;
+  esac
 
   if (( attempt == 3 )); then
     echo

--- a/scripts/notarize_direct_transaction.py
+++ b/scripts/notarize_direct_transaction.py
@@ -214,6 +214,53 @@ def _reject_duplicate_json_pairs(
     return result
 
 
+def preflight_notary_profile(
+    *,
+    project_root: Path,
+    notary_profile: str,
+    runner: CommandRunner,
+) -> None:
+    """Prove the configured Keychain profile works before durable state.
+
+    The history response is intentionally neither returned nor included in an
+    error. Besides keeping the preflight privacy-safe, this guarantees that a
+    missing, invalid, or unreachable profile fails before a notarization
+    transaction directory or submit-intent receipt can exist.
+    """
+    result = runner(
+        [
+            "xcrun",
+            "notarytool",
+            "history",
+            "--keychain-profile",
+            notary_profile,
+            "--output-format",
+            "json",
+        ],
+        project_root,
+    )
+    if result.returncode != 0:
+        raise DirectNotaryTransactionError(
+            "Keychain notary profile preflight failed"
+        )
+    try:
+        payload = json.loads(
+            result.output,
+            object_pairs_hook=_reject_duplicate_json_pairs,
+        )
+    except (json.JSONDecodeError, TypeError) as error:
+        raise DirectNotaryTransactionError(
+            "Keychain notary profile preflight returned invalid JSON"
+        ) from error
+    if (
+        not isinstance(payload, dict)
+        or not isinstance(payload.get("history"), list)
+    ):
+        raise DirectNotaryTransactionError(
+            "Keychain notary profile preflight returned invalid history"
+        )
+
+
 def parse_notary_result(
     output: str,
     *,
@@ -2204,6 +2251,11 @@ def run_transaction(
         raise DirectNotaryTransactionError(
             "prepared NeAntik.app is missing or unsafe"
         )
+    preflight_notary_profile(
+        project_root=project_root,
+        notary_profile=notary_profile,
+        runner=runner,
+    )
     (
         transaction_root,
         transaction_descriptor,

--- a/scripts/tests/test_notarize_direct_transaction.py
+++ b/scripts/tests/test_notarize_direct_transaction.py
@@ -38,6 +38,7 @@ class FakeReleaseRunner:
         info_identifier: str = SUBMISSION_ID,
         fail_final_verifier: bool = False,
         fail_submit: bool = False,
+        fail_history: bool = False,
         history_submission_name: str | None = None,
     ) -> None:
         self.commands: list[list[str]] = []
@@ -46,6 +47,7 @@ class FakeReleaseRunner:
         self.info_identifier = info_identifier
         self.fail_final_verifier = fail_final_verifier
         self.fail_submit = fail_submit
+        self.fail_history = fail_history
         self.history_submission_name = history_submission_name
 
     def package(self, source: Path, destination: Path) -> None:
@@ -125,6 +127,12 @@ class FakeReleaseRunner:
                 ),
             )
         if command[:3] == ["xcrun", "notarytool", "history"]:
+            if self.fail_history:
+                return MODULE.CommandResult(
+                    69,
+                    "sensitive history output must not escape",
+                    "sensitive credential error must not escape",
+                )
             history: dict[str, object] = {"history": []}
             if self.history_submission_name is not None:
                 history["history"] = [
@@ -156,6 +164,54 @@ class FakeReleaseRunner:
 
 
 class DirectNotaryTransactionTests(unittest.TestCase):
+    def test_missing_notary_profile_fails_before_durable_transaction(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            paths = self.fixture(root)
+            runner = FakeReleaseRunner(fail_history=True)
+            source_kwargs = self.source_kwargs(root)
+            initial_dist_entries = {
+                path.name for path in (root / "dist").iterdir()
+            }
+
+            with self.assertRaisesRegex(
+                MODULE.DirectNotaryTransactionError,
+                "Keychain notary profile preflight failed",
+            ) as raised:
+                MODULE.run_transaction(
+                    project_root=root,
+                    app=paths["app"],
+                    manifest=paths["manifest"],
+                    evidence=paths["evidence"],
+                    attestation=paths["attestation"],
+                    release_channel="public-alpha",
+                    notary_profile="missing-test-profile",
+                    runner=runner,
+                    **source_kwargs,
+                )
+
+            self.assertEqual(
+                {path.name for path in (root / "dist").iterdir()},
+                initial_dist_entries,
+            )
+            self.assertEqual(
+                runner.commands,
+                [
+                    [
+                        "xcrun",
+                        "notarytool",
+                        "history",
+                        "--keychain-profile",
+                        "missing-test-profile",
+                        "--output-format",
+                        "json",
+                    ]
+                ],
+            )
+            self.assertNotIn("sensitive", str(raised.exception))
+
     def test_no_wait_submission_accepts_identifier_without_status(
         self,
     ) -> None:

--- a/scripts/tests/test_release_runtime_evidence_cache.py
+++ b/scripts/tests/test_release_runtime_evidence_cache.py
@@ -1,4 +1,8 @@
+import os
 from pathlib import Path
+import shlex
+import subprocess
+import tempfile
 import unittest
 
 
@@ -7,6 +11,76 @@ RELEASE_COMMAND = ROOT / "scripts" / "Run-NeAntik-Release.command"
 
 
 class ReleaseRuntimeEvidenceCacheTests(unittest.TestCase):
+    def evaluate_gui_attempt(
+        self,
+        *,
+        timed_out: bool,
+        gui_exit_status: int,
+        evidence: str | None,
+    ) -> tuple[int, list[str]]:
+        text = RELEASE_COMMAND.read_text(encoding="utf-8")
+        functions_start = text.index(
+            "verify_current_gui_attempt_evidence() {"
+        )
+        functions_end = text.index("\nattempt=1", functions_start)
+        functions = text[functions_start:functions_end]
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            collector = scripts / "collect-gui-fingerprint-evidence.py"
+            collector.write_text(
+                """\
+import os
+from pathlib import Path
+import sys
+
+arguments = sys.argv[1:]
+Path(os.environ["ARG_LOG"]).write_text("\\n".join(arguments), encoding="utf-8")
+source = Path(arguments[arguments.index("--source") + 1])
+raise SystemExit(0 if source.is_file() and source.read_text(encoding="utf-8") == "valid" else 1)
+""",
+                encoding="utf-8",
+            )
+            evidence_path = root / "attempt-1" / "fingerprint-evidence-schema8.json"
+            evidence_path.parent.mkdir()
+            if evidence is not None:
+                evidence_path.write_text(evidence, encoding="utf-8")
+            argument_log = root / "collector-arguments.txt"
+            quote = shlex.quote
+
+            script = f"""\
+set +e
+PROJECT_DIR={quote(str(root))}
+SCHEMA8_SOURCE={quote(str(evidence_path))}
+APP_PATH={quote(str(root / 'NeAntik.app'))}
+CANDIDATE_MANIFEST={quote(str(root / 'direct-candidate-manifest.json'))}
+NEANTIK_RELEASE_CHANNEL=public-alpha
+GUI_NOT_BEFORE=2026-08-29T16:50:43Z
+REPORT_PATH={quote(str(root / 'fingerprint-audit.json'))}
+GUI_TIMED_OUT={1 if timed_out else 0}
+GUI_EXIT_STATUS={gui_exit_status}
+{functions}
+evaluate_current_gui_attempt
+exit $?
+"""
+            environment = os.environ.copy()
+            environment["ARG_LOG"] = str(argument_log)
+            completed = subprocess.run(
+                ["/bin/zsh", "-c", script],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+            arguments = (
+                argument_log.read_text(encoding="utf-8").splitlines()
+                if argument_log.exists()
+                else []
+            )
+            return completed.returncode, arguments
+
     def test_release_caches_verified_runtime_evidence_before_moving_candidate(self) -> None:
         text = RELEASE_COMMAND.read_text(encoding="utf-8")
 
@@ -89,8 +163,8 @@ class ReleaseRuntimeEvidenceCacheTests(unittest.TestCase):
             "wait-for-neantik-runtime-drain.py",
             second_drain + 1,
         )
-        collector = text.index(
-            "collect-gui-fingerprint-evidence.py",
+        evaluator = text.index(
+            "evaluate_current_gui_attempt ||",
             wait,
         )
         notarization = text.index(
@@ -98,11 +172,74 @@ class ReleaseRuntimeEvidenceCacheTests(unittest.TestCase):
         )
         self.assertLess(first_drain, launch)
         self.assertLess(wait, second_drain)
-        self.assertLess(second_drain, collector)
-        self.assertLess(collector, final_drain)
+        self.assertLess(second_drain, evaluator)
+        self.assertLess(evaluator, final_drain)
         self.assertLess(final_drain, notarization)
         self.assertNotIn("pkill", text)
         self.assertNotIn("kill -9", text)
+
+    def test_timeout_accepts_only_valid_evidence_from_the_same_attempt(self) -> None:
+        status, arguments = self.evaluate_gui_attempt(
+            timed_out=True,
+            gui_exit_status=143,
+            evidence="valid",
+        )
+
+        self.assertEqual(status, 0)
+        self.assertIn("--source", arguments)
+        source = arguments[arguments.index("--source") + 1]
+        self.assertTrue(source.endswith("attempt-1/fingerprint-evidence-schema8.json"))
+        self.assertEqual(
+            arguments[arguments.index("--not-before") + 1],
+            "2026-08-29T16:50:43Z",
+        )
+        self.assertIn("--integrated-app", arguments)
+        self.assertIn("--candidate-manifest", arguments)
+        self.assertEqual(
+            arguments[arguments.index("--release-channel") + 1],
+            "public-alpha",
+        )
+
+    def test_timeout_with_invalid_evidence_stays_fail_closed(self) -> None:
+        status, _ = self.evaluate_gui_attempt(
+            timed_out=True,
+            gui_exit_status=143,
+            evidence="invalid",
+        )
+
+        self.assertEqual(status, 67)
+
+    def test_timeout_with_missing_evidence_stays_fail_closed(self) -> None:
+        status, _ = self.evaluate_gui_attempt(
+            timed_out=True,
+            gui_exit_status=143,
+            evidence=None,
+        )
+
+        self.assertEqual(status, 67)
+
+    def test_timeout_success_still_requires_exact_source_binding(self) -> None:
+        text = RELEASE_COMMAND.read_text(encoding="utf-8")
+        evaluator = text.index("evaluate_current_gui_attempt ||")
+        binding = text.rindex(
+            'python3 "$PROJECT_DIR/scripts/direct-candidate-source-binding.py" verify'
+        )
+        notarization = text.index(
+            "[3/4] Отправляю кандидат в Apple notarization…"
+        )
+
+        self.assertLess(evaluator, binding)
+        self.assertLess(binding, notarization)
+
+    def test_non_timeout_nonzero_exit_does_not_accept_evidence(self) -> None:
+        status, arguments = self.evaluate_gui_attempt(
+            timed_out=False,
+            gui_exit_status=70,
+            evidence="valid",
+        )
+
+        self.assertEqual(status, 66)
+        self.assertEqual(arguments, [])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_verify_open_source_tree.py
+++ b/scripts/tests/test_verify_open_source_tree.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VERIFIER = ROOT / "scripts" / "verify-open-source-tree.py"
+SPEC = importlib.util.spec_from_file_location("verify_open_source_tree", VERIFIER)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class OpenSourceTreePrivacyTests(unittest.TestCase):
+    def test_personal_absolute_user_path_is_rejected(self) -> None:
+        leaked = "/" + "Users/" + "release-operator/private/report.json"
+        self.assertEqual(
+            MODULE.text_violation(Path("README.md"), leaked),
+            "personal absolute path",
+        )
+
+    def test_private_deployment_endpoint_is_rejected(self) -> None:
+        leaked = "deploy with " + "root" + "@" + "198.51.100.77"
+        self.assertEqual(
+            MODULE.text_violation(Path("docs/release.md"), leaked),
+            "private deployment endpoint",
+        )
+
+    def test_absolute_secret_store_path_is_rejected(self) -> None:
+        leaked = (
+            "/"
+            + "home/"
+            + "release-operator/project/"
+            + ".secrets/ssh/signing-key"
+        )
+        self.assertEqual(
+            MODULE.text_violation(Path("scripts/release.sh"), leaked),
+            "private secret-store path",
+        )
+
+    def test_synthetic_user_paths_are_limited_to_test_fixtures(self) -> None:
+        synthetic = "/" + "Users/" + "alice/private-fixture"
+        self.assertIsNone(
+            MODULE.text_violation(
+                Path("scripts/tests/test_privacy_fixture.py"), synthetic
+            )
+        )
+        self.assertEqual(
+            MODULE.text_violation(Path("README.md"), synthetic),
+            "personal absolute path",
+        )
+
+    def test_verifier_scans_its_own_source_without_a_blind_spot(self) -> None:
+        with mock.patch.object(
+            MODULE,
+            "text_violation",
+            return_value="synthetic self-test violation",
+        ):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), self.assertRaises(SystemExit):
+                MODULE.verify_files([VERIFIER])
+        self.assertIn("scripts/verify-open-source-tree.py", stderr.getvalue())
+
+    def test_real_operational_markers_are_not_stored_in_verifier(self) -> None:
+        text = VERIFIER.read_text(encoding="utf-8")
+        self.assertNotIn("/" + "Users/" + "dumay", text)
+        self.assertNotIn("root" + "@" + "135.181.253.143", text)
+        self.assertNotIn(
+            "/" + "Users/" + "dumay/AFF.job/" + ".secrets",
+            text,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-open-source-tree.py
+++ b/scripts/verify-open-source-tree.py
@@ -35,11 +35,19 @@ FORBIDDEN_NAMES = {
     ".DS_Store",
     ".env",
 }
-FORBIDDEN_TEXT = {
-    "/Users/dumay": "personal absolute path",
-    "root@135.181.253.143": "private deployment endpoint",
-    "/Users/dumay/AFF.job/.secrets": "private secret-store path",
-}
+PERSONAL_USER_PATH_RE = re.compile(
+    re.escape("/") + r"Users/(?P<username>[A-Za-z0-9._-]+)(?:/|$)"
+)
+PRIVATE_DEPLOYMENT_ENDPOINT_RE = re.compile(
+    r"(?<![A-Za-z0-9._-])root@[A-Za-z0-9][A-Za-z0-9.-]*\b"
+)
+PRIVATE_SECRET_STORE_PATH_RE = re.compile(
+    re.escape("/")
+    + r"(?:Users|home)/[^\"'\r\n]{1,256}/"
+    + r"(?:\.secrets|\.credentials|private[-_]?keys)(?:/|[\"'\s]|$)",
+    re.IGNORECASE,
+)
+SYNTHETIC_TEST_USERNAMES = frozenset({"alice", "example", "test"})
 SECRET_PATTERNS = {
     "private key": re.compile(r"BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY"),
     "GitHub token": re.compile(r"\bgh[opsu]_[A-Za-z0-9_]{20,}\b"),
@@ -129,6 +137,7 @@ REQUIRED_PUBLIC_PATHS = {
     "scripts/tests/test_verify_browser_identity_issuance.py",
     "scripts/tests/test_release_input_snapshot.py",
     "scripts/tests/test_verify_public_artifact_privacy.py",
+    "scripts/tests/test_verify_open_source_tree.py",
     "scripts/tests/test_runtime_audit_launcher.py",
     "scripts/tests/test_verify_direct_hosted_download_oss.py",
     "scripts/tests/test_verify_public_fingerprint_corpus.py",
@@ -214,11 +223,36 @@ def iter_public_files() -> list[Path]:
     return files
 
 
+def is_synthetic_test_user_path(relative: Path, username: str) -> bool:
+    parts = relative.parts
+    is_test_path = (
+        bool(parts) and parts[0] == "Tests"
+    ) or (
+        len(parts) >= 2 and parts[0] == "scripts" and parts[1] == "tests"
+    )
+    return is_test_path and username.lower() in SYNTHETIC_TEST_USERNAMES
+
+
+def text_violation(relative: Path, text: str) -> str | None:
+    if PRIVATE_SECRET_STORE_PATH_RE.search(text):
+        return "private secret-store path"
+
+    for match in PERSONAL_USER_PATH_RE.finditer(text):
+        if not is_synthetic_test_user_path(relative, match.group("username")):
+            return "personal absolute path"
+
+    if PRIVATE_DEPLOYMENT_ENDPOINT_RE.search(text):
+        return "private deployment endpoint"
+
+    for description, pattern in SECRET_PATTERNS.items():
+        if pattern.search(text):
+            return f"possible {description}"
+    return None
+
+
 def verify_files(files: list[Path]) -> None:
     for path in files:
         relative = path.relative_to(PROJECT_ROOT)
-        if path.resolve() == Path(__file__).resolve():
-            continue
         if path.name in FORBIDDEN_NAMES or path.suffix.lower() in FORBIDDEN_SUFFIXES:
             fail(f"forbidden file is present: {relative}")
         if path.suffix.lower() not in TEXT_SUFFIXES:
@@ -227,12 +261,9 @@ def verify_files(files: list[Path]) -> None:
             text = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        for needle, description in FORBIDDEN_TEXT.items():
-            if needle in text:
-                fail(f"{description} found in {relative}")
-        for description, pattern in SECRET_PATTERNS.items():
-            if pattern.search(text):
-                fail(f"possible {description} found in {relative}")
+        violation = text_violation(relative, text)
+        if violation is not None:
+            fail(f"{violation} found in {relative}")
 
 
 def verify_release_metadata() -> None:


### PR DESCRIPTION
## Summary
- remove real operator path and endpoint literals from the public source verifier, replace them with generic privacy checks, and scan the verifier itself
- fail before any durable notarization transaction when the configured Keychain profile is unavailable or malformed
- recover safely from a GUI timeout only when the same attempt already wrote fresh authenticated A→B→A evidence bound to the exact candidate

## Verification
- Swift: 544 tests / 55 suites
- Python: 593 tests / 1 intentional skip
- AffPapa: 24 tests
- ARM64 release build
- live manager + live fingerprint integration
- open-source/privacy/release contracts
- visual NeAntik Dev window review
- live site clicks for demo, FAQ, GitHub, DMG and ZIP

Public release remains 0.3.19 (22). No notarization or publication is performed by this PR.