### PR TITLE
Accept Apple team wildcard in Developer ID profiles

### DIFF
--- a/scripts/tests/test_verify_direct_provisioning_profile.py
+++ b/scripts/tests/test_verify_direct_provisioning_profile.py
@@ -49,6 +49,13 @@ class DirectProvisioningProfileTests(unittest.TestCase):
     def test_accepts_exact_developer_id_distribution_profile(self) -> None:
         self.validate(valid_profile())
 
+    def test_accepts_apple_team_wildcard_keychain_authorization(self) -> None:
+        profile = valid_profile()
+        entitlements = dict(profile["Entitlements"])
+        entitlements["keychain-access-groups"] = [f"{TEAM_ID}.*"]
+        profile["Entitlements"] = entitlements
+        self.validate(profile)
+
     def test_rejects_expired_profile(self) -> None:
         profile = valid_profile()
         profile["ExpirationDate"] = dt.datetime(2020, 1, 1)
@@ -71,6 +78,16 @@ class DirectProvisioningProfileTests(unittest.TestCase):
             "com.apple.developer.team-identifier": TEAM_ID,
             "keychain-access-groups": [f"{TEAM_ID}.wrong.bundle"],
         }
+        with self.assertRaisesRegex(
+            MODULE.ProvisioningProfileError, "Keychain access group"
+        ):
+            self.validate(profile)
+
+    def test_rejects_foreign_team_wildcard_keychain_group(self) -> None:
+        profile = valid_profile()
+        entitlements = dict(profile["Entitlements"])
+        entitlements["keychain-access-groups"] = ["WRONGTEAM.*"]
+        profile["Entitlements"] = entitlements
         with self.assertRaisesRegex(
             MODULE.ProvisioningProfileError, "Keychain access group"
         ):

--- a/scripts/verify-direct-provisioning-profile.py
+++ b/scripts/verify-direct-provisioning-profile.py
@@ -350,7 +350,10 @@ def validate_profile_payload(
             "profile does not authorize the NeAntik developer team"
         )
     groups = entitlements.get("keychain-access-groups")
-    if not isinstance(groups, list) or application_id not in groups:
+    authorized_groups = {application_id, f"{team_id}.*"}
+    if not isinstance(groups, list) or not any(
+        isinstance(group, str) and group in authorized_groups for group in groups
+    ):
         raise ProvisioningProfileError(
             "profile does not authorize the NeAntik Keychain access group"
         )


### PR DESCRIPTION
## Summary
- accept Apple-issued `H6VGU2M6JD.*` authorization for the exact NeAntik Keychain group
- keep exact application/team identity checks unchanged
- reject wildcard groups from other teams

Apple documents that a team wildcard authorizes keychain groups with that team prefix: https://developer.apple.com/documentation/technotes/tn3125-inside-code-signing-provisioning-profiles

## Verification
- `python3 -m unittest discover -s scripts/tests -p "test_*.py"` (637 tests, 1 skip)
- real Apple `MAC_APP_DIRECT` profile for `app.neantik.desktop` passes the verifier

No release artifact or public version is changed by this PR.