### PR TITLE
Fail fast on provisioning certificate mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Direct release preflight now verifies that the external provisioning
+  profile actually authorizes the exact pinned Developer ID certificate, then
+  repeats that certificate-to-profile check on the signed app before Secure
+  Enclave enrollment. A wrong certificate selection now fails before the
+  expensive build instead of being killed later by macOS `taskgated`.
+
 ## Direct 0.3.23 (26) — September 1, 2026
 
 - GitHub README and project documentation now identify the actual immutable

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -134,7 +134,7 @@ the repository or GitHub Actions secrets for the initial public workflow.
 The local release path is:
 
 ```bash
-export NEANTIK_SIGNING_IDENTITY="Developer ID Application: …"
+export NEANTIK_SIGNING_IDENTITY="40-HEX-SHA1-OF-DEVELOPER-ID-CERTIFICATE"
 export NEANTIK_NOTARY_PROFILE="your-keychain-profile"
 export NEANTIK_RELEASE_CHANNEL="public-alpha" # or production
 export NEXT_PUBLIC_NEANTIK_DOWNLOAD_URL="https://example.com/NeAntik-VERSION-arm64-notarized.zip"
@@ -150,6 +150,11 @@ export NEXT_PUBLIC_NEANTIK_DOWNLOAD_URL="https://example.com/NeAntik-VERSION-arm
 # Then collect that explicit schema-8 file against the same manifest/channel.
 ./scripts/release-direct.sh
 ```
+
+The external Developer ID provisioning profile must list that same certificate
+under `DeveloperCertificates`. A display name is accepted only when it resolves
+to one installed identity; use the certificate SHA-1 whenever two identities
+have the same name.
 
 The first phase signs and freshly verifies the built runtime, promotes the
 candidate source lock only after the Metal binary report matches, regenerates

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -195,8 +195,11 @@ input and must be supplied through `NEANTIK_PROVISIONING_PROFILE`. Source gates
 reject both `.provisionprofile` and `.mobileprovision` files in the public
 repository. The profile must be Apple-signed, unexpired, distribution-wide,
 and authorize the exact NeAntik Team ID, application identifier, and Keychain
-access group; development, ad hoc, debug and App Store sandbox profiles fail
-closed.
+access group. Its `DeveloperCertificates` must also contain the exact
+Developer ID certificate selected by `NEANTIK_SIGNING_IDENTITY`; the release
+gate checks this before the expensive build and checks the final app
+certificate again before Secure Enclave enrollment. Development, ad hoc,
+debug and App Store sandbox profiles fail closed.
 
 The initial GitHub workflow builds and tests unsigned source only. Signed
 release artifacts are produced on the trusted local Apple Silicon builder and

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -8,6 +8,10 @@ product and code work. The older v4 documents remain dated design records.
 - Latest immutable GitHub release: `v0.3.22`, version/build `0.3.22 (25)`.
 - Current source candidate: `0.3.23 (26)`; it is not public until the full
   Direct Distribution gate completes.
+- The first `0.3.23 (26)` release attempt on exact merge commit
+  `888e73a9c897303ba179da473f226572a89ee6fd` stopped before Secure Enclave
+  enrollment because the external provisioning profile authorized a different
+  Developer ID certificate. No `v0.3.23` release or public asset exists.
 - Exact released source commit:
   `160c4e71cb1aee76d940bc2d07ad64ed014bf54f`.
 - Runtime: Chromium `152.0.7977.64`, ARM64, Metal.
@@ -43,7 +47,7 @@ network API, arbitrary low-level fingerprint sliders or secret export.
 | Proxy | `ProxyTester.swift`, `ProxyHealth*.swift`, `BulkProxyImport.swift`, `ProxyImportParser.swift` | Local parsing, bounded concurrency, fresh preparation before proxied launch |
 | Fingerprint evidence | `FingerprintAudit*.swift`, `FingerprintEvidence*.swift`, `SecureEnclaveFingerprintEvidenceSigner.swift` | Release-only strict evidence is separate from ordinary diagnostics |
 | Readiness and notices | `WorkspaceReadiness*.swift`, `UserNotice.swift` | Redacted, actionable, semantically honest local diagnostics |
-| Release operations | `Release-NeAntik.command`, `scripts/prepare-direct-*.sh`, `scripts/neantik-affpapa-release` | Exact candidate only; GitHub doctor is server-free, site publish is explicit; never App Store Connect |
+| Release operations | `Release-NeAntik.command`, `scripts/prepare-direct-*.sh`, `scripts/verify-direct-provisioning-profile.py`, `scripts/neantik-affpapa-release` | Exact candidate only; profile must authorize the selected signing certificate; GitHub doctor is server-free, site publish is explicit; never App Store Connect |
 
 ## Current capability state
 

--- a/docs/SOURCE_TO_SITE_HANDOFF.md
+++ b/docs/SOURCE_TO_SITE_HANDOFF.md
@@ -16,6 +16,9 @@ Status: reconciled 2026-09-01.
 
 ## Next release handoff
 
+0. Generate the external Developer ID provisioning profile with the exact
+   certificate selected by `NEANTIK_SIGNING_IDENTITY`; the local gate must
+   confirm that `DeveloperCertificates` binding before any expensive build.
 1. Assign a version and build newer than `0.3.22 (25)`.
 2. Move `CHANGELOG.md` from Unreleased to `Direct VERSION (BUILD)` and update
    both READMEs before building.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -140,7 +140,7 @@ bundle, verifies it, promotes the exact candidate lock and regenerates notices:
 
 ```sh
 NEANTIK_RELEASE_CHANNEL=public-alpha \
-NEANTIK_SIGNING_IDENTITY="Developer ID Application: …" \
+NEANTIK_SIGNING_IDENTITY="40-HEX-SHA1-OF-DEVELOPER-ID-CERTIFICATE" \
 scripts/prepare-direct-runtime-candidate.sh \
   "/absolute/path/to/NeAntik Browser.app" \
   /absolute/path/to/out/Default/args.gn \

--- a/scripts/prepare-direct-manager-update.sh
+++ b/scripts/prepare-direct-manager-update.sh
@@ -159,7 +159,8 @@ if [[ "${NEANTIK_LOCAL_ADHOC:-0}" != "1" ]]; then
   : "${NEANTIK_PROVISIONING_PROFILE:?Set NEANTIK_PROVISIONING_PROFILE to the absolute Developer ID distribution provisioning profile path}"
   python3 "$PROJECT_DIR/scripts/verify-direct-provisioning-profile.py" \
     --profile "$NEANTIK_PROVISIONING_PROFILE" \
-    --entitlements "$RELEASE_ENTITLEMENTS"
+    --entitlements "$RELEASE_ENTITLEMENTS" \
+    --signing-identity "$NEANTIK_SIGNING_IDENTITY"
 fi
 
 "$PROJECT_DIR/scripts/verify-runtime-security-baseline.py" \
@@ -228,6 +229,7 @@ if [[ "${NEANTIK_LOCAL_ADHOC:-0}" != "1" ]]; then
   python3 "$PROJECT_DIR/scripts/verify-direct-provisioning-profile.py" \
     --profile "$NEANTIK_PROVISIONING_PROFILE" \
     --entitlements "$RELEASE_ENTITLEMENTS" \
+    --signing-identity "$NEANTIK_SIGNING_IDENTITY" \
     --copy-to "$EMBEDDED_PROFILE"
 fi
 verify_reviewed_runtime_evidence
@@ -255,6 +257,7 @@ if [[ "${NEANTIK_LOCAL_ADHOC:-0}" != "1" ]]; then
   python3 "$PROJECT_DIR/scripts/verify-direct-provisioning-profile.py" \
     --profile "$EMBEDDED_PROFILE" \
     --entitlements "$RELEASE_ENTITLEMENTS" \
+    --signing-identity "$NEANTIK_SIGNING_IDENTITY" \
     --app "$CANDIDATE_APP"
 fi
 

--- a/scripts/prepare-direct-runtime-candidate.sh
+++ b/scripts/prepare-direct-runtime-candidate.sh
@@ -65,7 +65,8 @@ esac
 : "${NEANTIK_PROVISIONING_PROFILE:?Set NEANTIK_PROVISIONING_PROFILE to the absolute Developer ID distribution provisioning profile path}"
 python3 "$PROJECT_DIR/scripts/verify-direct-provisioning-profile.py" \
   --profile "$NEANTIK_PROVISIONING_PROFILE" \
-  --entitlements "$RELEASE_ENTITLEMENTS"
+  --entitlements "$RELEASE_ENTITLEMENTS" \
+  --signing-identity "$NEANTIK_SIGNING_IDENTITY"
 
 METAL_TRUE_COUNT="$(
   grep -Ec \
@@ -138,6 +139,7 @@ rm -f "$EMBEDDED_PROFILE"
 python3 "$PROJECT_DIR/scripts/verify-direct-provisioning-profile.py" \
   --profile "$NEANTIK_PROVISIONING_PROFILE" \
   --entitlements "$RELEASE_ENTITLEMENTS" \
+  --signing-identity "$NEANTIK_SIGNING_IDENTITY" \
   --copy-to "$EMBEDDED_PROFILE"
 codesign \
   --force \
@@ -150,6 +152,7 @@ codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 python3 "$PROJECT_DIR/scripts/verify-direct-provisioning-profile.py" \
   --profile "$EMBEDDED_PROFILE" \
   --entitlements "$RELEASE_ENTITLEMENTS" \
+  --signing-identity "$NEANTIK_SIGNING_IDENTITY" \
   --app "$APP_PATH"
 "$PROJECT_DIR/scripts/verify-integrated-release.sh" "$APP_PATH"
 

--- a/scripts/tests/test_release_direct_script.py
+++ b/scripts/tests/test_release_direct_script.py
@@ -196,6 +196,7 @@ class ReleaseDirectScriptTests(unittest.TestCase):
             "ProvisionedDevices",
             "ExpirationDate",
             "TeamIdentifier",
+            "DeveloperCertificates",
             "com.apple.application-identifier",
             "com.apple.developer.team-identifier",
             "keychain-access-groups",
@@ -209,6 +210,10 @@ class ReleaseDirectScriptTests(unittest.TestCase):
             self.assertIn("NEANTIK_PROVISIONING_PROFILE", text)
             self.assertIn("verify-direct-provisioning-profile.py", text)
             self.assertIn('--entitlements "$RELEASE_ENTITLEMENTS"', text)
+            self.assertIn(
+                '--signing-identity "$NEANTIK_SIGNING_IDENTITY"',
+                text,
+            )
 
     def test_release_only_verifies_and_notarizes_prepared_candidate(self) -> None:
         text = RELEASE.read_text(encoding="utf-8")

--- a/scripts/tests/test_verify_direct_provisioning_profile.py
+++ b/scripts/tests/test_verify_direct_provisioning_profile.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import importlib.util
+import subprocess
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -18,6 +21,7 @@ SPEC.loader.exec_module(MODULE)
 TEAM_ID = "H6VGU2M6JD"
 BUNDLE_ID = "app.neantik.desktop"
 APPLICATION_ID = f"{TEAM_ID}.{BUNDLE_ID}"
+PROFILE_CERTIFICATE = b"synthetic Developer ID certificate"
 
 
 def valid_profile() -> dict[str, object]:
@@ -28,6 +32,7 @@ def valid_profile() -> dict[str, object]:
         "TeamIdentifier": [TEAM_ID],
         "Platform": ["OSX"],
         "ProvisionsAllDevices": True,
+        "DeveloperCertificates": [PROFILE_CERTIFICATE],
         "Entitlements": {
             "com.apple.application-identifier": APPLICATION_ID,
             "com.apple.developer.team-identifier": TEAM_ID,
@@ -70,6 +75,67 @@ class DirectProvisioningProfileTests(unittest.TestCase):
             MODULE.ProvisioningProfileError, "Developer ID distribution"
         ):
             self.validate(profile)
+
+    def test_rejects_profile_without_authorized_signing_certificate(self) -> None:
+        profile = valid_profile()
+        profile["DeveloperCertificates"] = []
+        with self.assertRaisesRegex(
+            MODULE.ProvisioningProfileError,
+            "no authorized Developer ID signing certificate",
+        ):
+            self.validate(profile)
+
+    def test_declared_signer_must_be_authorized_by_profile(self) -> None:
+        profile = valid_profile()
+        fingerprint = hashlib.sha1(
+            PROFILE_CERTIFICATE, usedforsecurity=False
+        ).hexdigest().upper()
+        unauthorized = "A" * 40
+        installed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                f'  1) {fingerprint} "Developer ID Application: NeAntik"\n'
+                f'  2) {unauthorized} "Developer ID Application: Other"\n'
+            ).encode(),
+            stderr=b"",
+        )
+        with mock.patch.object(MODULE.subprocess, "run", return_value=installed):
+            MODULE.validate_declared_signing_identity(profile, fingerprint)
+            with self.assertRaisesRegex(
+                MODULE.ProvisioningProfileError,
+                "does not authorize",
+            ):
+                MODULE.validate_declared_signing_identity(profile, unauthorized)
+
+    def test_signed_app_certificate_must_match_profile(self) -> None:
+        profile = valid_profile()
+        rejected = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout=b"", stderr=b""
+        )
+        accepted = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=b"", stderr=b""
+        )
+        with mock.patch.object(
+            MODULE.subprocess,
+            "run",
+            side_effect=[rejected],
+        ):
+            with self.assertRaisesRegex(
+                MODULE.ProvisioningProfileError,
+                "signed app certificate",
+            ):
+                MODULE.validate_signed_app_certificate(
+                    Path("/tmp/NeAntik.app"), profile
+                )
+        with mock.patch.object(
+            MODULE.subprocess,
+            "run",
+            side_effect=[accepted],
+        ):
+            MODULE.validate_signed_app_certificate(
+                Path("/tmp/NeAntik.app"), profile
+            )
 
     def test_rejects_wrong_keychain_group(self) -> None:
         profile = valid_profile()

--- a/scripts/verify-direct-provisioning-profile.py
+++ b/scripts/verify-direct-provisioning-profile.py
@@ -297,6 +297,106 @@ def validate_source_entitlements(
         raise ProvisioningProfileError("release application identifier is invalid")
 
 
+def profile_developer_certificate_sha1s(
+    profile: dict[str, Any],
+) -> frozenset[str]:
+    certificates = profile.get("DeveloperCertificates")
+    if not isinstance(certificates, list) or not certificates:
+        raise ProvisioningProfileError(
+            "profile has no authorized Developer ID signing certificate"
+        )
+    fingerprints: set[str] = set()
+    for certificate in certificates:
+        if not isinstance(certificate, bytes) or not certificate:
+            raise ProvisioningProfileError(
+                "profile DeveloperCertificates entry is invalid"
+            )
+        # Apple code-signing requirements identify leaf certificates by SHA-1.
+        # This is an equality key, not a content-integrity decision.
+        fingerprints.add(
+            hashlib.sha1(certificate, usedforsecurity=False).hexdigest().upper()
+        )
+    return frozenset(fingerprints)
+
+
+def resolve_signing_identity_sha1(identity: str) -> str:
+    identity = identity.strip()
+    if not identity:
+        raise ProvisioningProfileError("signing identity is empty")
+    completed = subprocess.run(
+        ["/usr/bin/security", "find-identity", "-v", "-p", "codesigning"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=30,
+    )
+    if completed.returncode != 0:
+        raise ProvisioningProfileError(
+            "installed code-signing identities could not be inspected"
+        )
+    text = (completed.stdout + b"\n" + completed.stderr).decode(
+        "utf-8", errors="replace"
+    )
+    available: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        match = re.match(
+            r'^\s*\d+\)\s+([0-9A-Fa-f]{40})\s+"([^"]+)"',
+            line,
+        )
+        if match:
+            available.append((match.group(1).upper(), match.group(2)))
+    requested_sha1 = (
+        identity.upper()
+        if re.fullmatch(r"[0-9A-Fa-f]{40}", identity)
+        else None
+    )
+    matches = {
+        fingerprint
+        for fingerprint, common_name in available
+        if fingerprint == requested_sha1 or common_name == identity
+    }
+    if not matches:
+        raise ProvisioningProfileError(
+            "declared Developer ID signing identity is not installed"
+        )
+    if len(matches) != 1:
+        raise ProvisioningProfileError(
+            "declared Developer ID signing identity is ambiguous; use its SHA-1"
+        )
+    return next(iter(matches))
+
+
+def validate_declared_signing_identity(
+    profile: dict[str, Any],
+    identity: str,
+) -> None:
+    signing_sha1 = resolve_signing_identity_sha1(identity)
+    if signing_sha1 not in profile_developer_certificate_sha1s(profile):
+        raise ProvisioningProfileError(
+            "profile does not authorize the declared Developer ID signing certificate"
+        )
+
+
+def validate_signed_app_certificate(
+    app_path: Path,
+    profile: dict[str, Any],
+) -> None:
+    for fingerprint in profile_developer_certificate_sha1s(profile):
+        requirement = f'certificate leaf = H"{fingerprint}"'
+        checked = subprocess.run(
+            ["/usr/bin/codesign", "-v", f"-R={requirement}", str(app_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=30,
+        )
+        if checked.returncode == 0:
+            return
+    raise ProvisioningProfileError(
+        "signed app certificate is not authorized by its provisioning profile"
+    )
+
+
 def _normalized_utc(value: dt.datetime) -> dt.datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=dt.timezone.utc)
@@ -337,6 +437,7 @@ def validate_profile_payload(
         raise ProvisioningProfileError(
             "device-limited development or ad hoc profile is forbidden"
         )
+    profile_developer_certificate_sha1s(profile)
 
     entitlements = profile.get("Entitlements")
     if not isinstance(entitlements, dict):
@@ -387,6 +488,7 @@ def validate_signed_app(
     app_path: Path,
     *,
     profile_bytes: bytes,
+    profile: dict[str, Any],
     source_entitlements: dict[str, Any],
     bundle_id: str,
     team_id: str,
@@ -413,6 +515,7 @@ def validate_signed_app(
     )
     if verified.returncode != 0:
         raise ProvisioningProfileError("signed app failed codesign verification")
+    validate_signed_app_certificate(app_path, profile)
     displayed = subprocess.run(
         ["/usr/bin/codesign", "-d", "--entitlements", ":-", str(app_path)],
         stdout=subprocess.PIPE,
@@ -496,6 +599,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--profile", required=True, type=Path)
     parser.add_argument("--info-plist", type=Path, default=DEFAULT_INFO_PLIST)
     parser.add_argument("--entitlements", type=Path, default=DEFAULT_ENTITLEMENTS)
+    parser.add_argument("--signing-identity")
     parser.add_argument("--copy-to", type=Path)
     parser.add_argument("--app", type=Path)
     return parser.parse_args()
@@ -521,12 +625,15 @@ def main() -> None:
             team_id=team_id,
             application_id=application_id,
         )
+        if args.signing_identity is not None:
+            validate_declared_signing_identity(profile, args.signing_identity)
         if args.copy_to is not None:
             _copy_profile(profile_bytes, args.copy_to)
         if args.app is not None:
             validate_signed_app(
                 args.app,
                 profile_bytes=profile_bytes,
+                profile=profile,
                 source_entitlements=entitlements,
                 bundle_id=bundle_id,
                 team_id=team_id,


### PR DESCRIPTION
## Summary
- bind the external Developer ID provisioning profile to the exact selected signing certificate before expensive release work
- verify the final signed app certificate against the embedded profile before Secure Enclave enrollment
- record the stopped 0.3.23 attempt and update release/project runbooks

## Verification
- 640 Python tests passed, 1 skipped
- zsh syntax checks passed for affected release scripts
- open-source/secret-material gate passed (473 files)
- live bad-profile check now fails immediately with: profile does not authorize the declared Developer ID signing certificate

## Release boundary
No release, tag, asset, notarization retry, website or server change is part of this PR. Public latest remains v0.3.22.