### PR TITLE
Allow concise reviewed notes for pinned site releases

### DIFF
--- a/ops/affpapa/tests/test_prepare_release_snapshot.py
+++ b/ops/affpapa/tests/test_prepare_release_snapshot.py
@@ -20,6 +20,36 @@ SPEC.loader.exec_module(MODULE)
 
 
 class PrepareReleaseSnapshotTests(unittest.TestCase):
+    def test_curated_notes_reject_invalid_input_before_staging(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            notes = root / "notes.json"
+            output = root / "absent-parent/release"
+            for value in ({}, [], ["ok"] * 31, [""], ["   "], [False], ["x" * 501], ["<b>HTML</b>"], ["text\nline"], ["text\x7f"]):
+                with self.subTest(value=value):
+                    notes.write_text(json.dumps(value), encoding="utf-8")
+                    args = argparse.Namespace(project_root=root, output=output, release_notes_json=notes)
+                    with patch.object(MODULE, "git_commit") as git, self.assertRaises(MODULE.SnapshotError):
+                        MODULE.build_snapshot(args)
+                    git.assert_not_called()
+                    self.assertFalse(output.parent.exists())
+
+    def test_curated_notes_boundary_and_file_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            notes = root / "notes.json"
+            items = ["я" * 500] * 30
+            notes.write_text(json.dumps(items), encoding="utf-8")
+            self.assertEqual(MODULE.read_curated_release_notes(notes), items)
+            alias = root / "alias.json"
+            alias.symlink_to(notes)
+            with self.assertRaises(MODULE.SnapshotError):
+                MODULE.read_curated_release_notes(alias)
+            for raw in (b"[", b"\xff", b" " * 100_001):
+                notes.write_bytes(raw)
+                with self.assertRaises(ValueError):
+                    MODULE.read_curated_release_notes(notes)
+
     def test_reads_multiline_notes_for_exact_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             changelog = Path(temporary) / "CHANGELOG.md"
@@ -216,6 +246,12 @@ class ReleaseSourceSeparationTests(unittest.TestCase):
     """The release source, not the release tooling, defines what is published."""
 
     def test_pinned_release_source_beats_newer_tooling_commit(self) -> None:
+        self.assert_pinned_snapshot()
+
+    def test_curated_notes_override_only_current_items(self) -> None:
+        self.assert_pinned_snapshot(["Понятные настройки и заметки профилей."])
+
+    def assert_pinned_snapshot(self, curated: list[str] | None = None) -> None:
         source = release_source_tree()
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary) / "project"
@@ -234,6 +270,10 @@ class ReleaseSourceSeparationTests(unittest.TestCase):
                 release_tag=RELEASE_TAG,
                 release_commit=RELEASE_COMMIT,
             )
+            if curated is not None:
+                notes = Path(temporary) / "notes.json"
+                notes.write_text(json.dumps(curated), encoding="utf-8")
+                args.release_notes_json = notes
             with (
                 patch.object(
                     MODULE, "git_commit", return_value=TOOLING_COMMIT
@@ -260,7 +300,14 @@ class ReleaseSourceSeparationTests(unittest.TestCase):
             self.assertEqual(release["version"], "0.3.17")
             self.assertEqual(release["build"], 20)
             self.assertEqual(release["runtime"]["version"], "152.0.7977.64")
-            self.assertEqual(content["changelog"][0]["items"], [PINNED_ITEM])
+            self.assertEqual(content["changelog"][0]["items"], curated or [PINNED_ITEM])
+            original_content = json.loads(source["ops/affpapa/bootstrap/content.json"])
+            self.assertEqual(content["changelog"][1:], original_content["changelog"])
+            self.assertEqual(content["changelog"][0]["version"], "0.3.17")
+            self.assertEqual(content["changelog"][0]["build"], 20)
+            self.assertEqual(len(list(output.iterdir())), 6)
+            self.assertEqual((output / dmg.name).read_bytes(), b"dmg")
+            self.assertEqual((output / zip_file.name).read_bytes(), b"zip")
             self.assertEqual(result["releaseCommit"], RELEASE_COMMIT)
             self.assertEqual(result["toolingCommit"], TOOLING_COMMIT)
             self.assertEqual(result["releaseSourcePinned"], "yes")

--- a/scripts/prepare-affpapa-release-snapshot.py
+++ b/scripts/prepare-affpapa-release-snapshot.py
@@ -13,7 +13,9 @@ commit the published binaries were built from. When `--release-tag` and
 (version, build, changelog, runtime) is read out of that exact commit with
 `git show`, never out of the newer worktree, and the pinned pair is confirmed
 against the GitHub tag, the immutable release flag and per-asset release
-attestations before anything is written.
+attestations before anything is written. An explicit --release-notes-json may
+replace only the current changelog's display items with a reviewed summary;
+it never overrides pinned version, build, runtime, source or artifact facts.
 """
 
 from __future__ import annotations
@@ -77,6 +79,30 @@ def regular_file(path: Path) -> Path:
     if not stat.S_ISREG(metadata.st_mode):
         raise SnapshotError(f"Required input must be a regular file: {path}")
     return path
+
+
+def read_curated_release_notes(path: Path) -> list[str]:
+    regular_file(path)
+    # Bound input before decoding; 30 JSON-escaped Unicode notes fit this cap.
+    with path.open("rb") as source:
+        raw = source.read(100_001)
+    if len(raw) > 100_000:
+        raise SnapshotError("Release notes JSON exceeds 100000 bytes")
+    items = json.loads(raw.decode("utf-8"))
+    if not isinstance(items, list) or not 1 <= len(items) <= 30:
+        raise SnapshotError("Release notes must contain 1..30 strings")
+    for index, item in enumerate(items):
+        if not isinstance(item, str) or not item.strip() or len(item) > 500:
+            raise SnapshotError(
+                f"Release note {index + 1} must be a non-empty string up to 500 characters"
+            )
+        if "<" in item or ">" in item or any(
+            ord(char) < 32 or ord(char) == 127 for char in item
+        ):
+            raise SnapshotError(
+                f"Release note {index + 1} must be plain text without HTML or control characters"
+            )
+    return items
 
 
 def file_sha256(path: Path) -> str:
@@ -288,6 +314,10 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, str]:
     output = args.output.resolve()
     if output.exists() or output.is_symlink():
         raise SnapshotError(f"Output already exists: {output}")
+    notes_path = getattr(args, "release_notes_json", None)
+    curated_notes = (
+        read_curated_release_notes(notes_path) if notes_path is not None else None
+    )
     release_date = dt.date.fromisoformat(args.release_date)
     release_tag = getattr(args, "release_tag", None)
     release_commit = getattr(args, "release_commit", None)
@@ -392,7 +422,10 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, str]:
                     "build": build,
                     "date": russian_display_date(release_date),
                     "label": "Public Alpha",
-                    "items": parse_release_notes(changelog, version, build),
+                    "items": (
+                        curated_notes if curated_notes is not None
+                        else parse_release_notes(changelog, version, build)
+                    ),
                 },
                 *previous,
             ],
@@ -438,6 +471,13 @@ def main() -> int:
     parser.add_argument("--zip", type=Path, required=True)
     parser.add_argument("--release-date", required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--release-notes-json", type=Path,
+        help=(
+            "reviewed JSON array of 1..30 plain-text release notes, at most "
+            "500 characters each; overrides only current changelog items"
+        ),
+    )
     parser.add_argument(
         "--release-tag",
         help=(


### PR DESCRIPTION
Add optional bounded plain-text release notes JSON for website snapshots. Pinned release version/build/runtime/source and assets remain unchanged. Server validator unchanged. 46 AffPapa tests passed. This tooling-only change does not rebuild published v0.3.24 artifacts.