### PR TITLE
Align NeAntik site with workplaces and clarify local privacy

### DIFF
--- a/ops/affpapa/bootstrap/neantik.blade.php
+++ b/ops/affpapa/bootstrap/neantik.blade.php
@@ -1,7 +1,7 @@
 @extends('affpapa.layout')
 
-@section('title', 'NeAntik — антидетект-браузер для Apple Silicon Mac | AffPapa')
-@section('description', 'NeAntik — нативный менеджер браузерных профилей для macOS со встроенным Chromium. Изолированные сессии, прокси и локальное хранение. SwiftUI, без Electron, без облака.')
+@section('title', 'NeAntik — рабочие места в браузере для Mac | AffPapa')
+@section('description', 'У каждого дела — свой интернет. NeAntik сохраняет отдельные браузерные сессии на Mac: свои входы на сайты, cookies и данные. Прокси по необходимости, без регистрации.')
 @section('canonical', 'https://affpapa.org/neantik')
 
 @php
@@ -509,15 +509,28 @@
         </div>
     </section>
 
+    @if (version_compare($releaseVersion, '0.5.0', '>='))
+    <section class="section nk-reveal" id="neantik-workplaces">
+        <div class="section-head"><h2>Найти. Открыть. Продолжить.</h2></div>
+        <div class="nk-features">
+            <div class="card nk-feat"><h3>Нужное дело рядом</h3><p>Главный экран показывает закреплённые и недавние рабочие места. Поиск находит их по имени, тегам и заметке.</p></div>
+            <div class="card nk-feat"><h3>Вернуться в своё окно</h3><p>«Открыть» запускает браузер, «Продолжить» возвращает в подтверждённое окно. Остановка доступна отдельно в каталоге.</p></div>
+            <div class="card nk-feat"><h3>Переключиться из меню Mac</h3><p>Меню NeAntik в строке меню macOS открывает недавние рабочие места. Имя активного окна показывается после проверки его принадлежности.</p></div>
+            <div class="card nk-feat"><h3>Сложное — по необходимости</h3><p>⌘1 открывает главный экран, ⌘2 — полный каталог с папками, архивом и диагностикой. Данные существующих профилей сохраняются.</p></div>
+        </div>
+        <p class="muted">Браузерные окна остаются отдельными. Общая оболочка вкладок внутри Chromium в версии 0.5.0 не реализована.</p>
+    </section>
+    @endif
+
     {{-- ═══ SCREENSHOTS ═══ --}}
     <section class="section nk-reveal" id="neantik-screenshots">
-        <div class="section-head"><h2>Как выглядит NeAntik</h2></div>
+        <div class="section-head"><h2>Схемы возможностей NeAntik</h2></div>
         <div class="nk-screenshots">
             <div class="nk-screenshot nk-reveal" style="transition-delay:0ms">
                 <img src="/img/neantik/profiles.svg" alt="NeAntik — менеджер профилей" width="1440" height="900" loading="lazy">
                 <div class="nk-screenshot__caption">
                     <h3>Профили и запуск</h3>
-                    <p>Локальные профили, понятный статус proxy и быстрый запуск браузера без тяжёлой shell-платформы.</p>
+                    <p>Иллюстрация каталога: отдельные профили, состояние подключения и запуск браузера.</p>
                 </div>
             </div>
             <div class="nk-screenshot nk-reveal" style="transition-delay:80ms">
@@ -541,9 +554,9 @@
     <section class="section nk-reveal" id="neantik-problem">
         <div class="section-head"><h2>Профили должны разделять контексты, а&nbsp;не&nbsp;усложнять работу</h2></div>
         <div class="nk-problem">
-            <p>Режим инкогнито не&nbsp;создаёт новое устройство для сайта. Cookies можно очистить, но&nbsp;Canvas, WebGL, Audio, GPU, timezone и&nbsp;другие сигналы остаются связанными с&nbsp;тем&nbsp;же браузером и&nbsp;Mac.</p>
-            <p>Большие антидетект-платформы решают эту задачу вместе с&nbsp;облаком, командами, API, RPA и&nbsp;десятками настроек. Это полезно для масштабных операций, но&nbsp;лишнее, если нужны несколько постоянных локальных контекстов на&nbsp;одном Mac.</p>
-            <p>NeAntik оставляет только основу: профиль, proxy, встроенный Chromium и&nbsp;стабильная identity. Сложная диагностика остаётся внутри release-процесса.</p>
+            <p>Один проект — одни входы на сайты, другой — другие. Создайте для каждого дела своё рабочее место и возвращайтесь в сохранённую сессию.</p>
+            <p>Рабочее место — это отдельный профиль Chromium. Cookies и данные сайтов сохраняются внутри него; при переходе на новую версию существующие профили не нужно создавать заново.</p>
+            <p>Прокси нужен только тогда, когда вашему делу требуется отдельное подключение. Папки, архив и диагностика доступны в полном каталоге.</p>
         </div>
     </section>
 
@@ -615,7 +628,7 @@
             <div class="card nk-feat nk-reveal" style="transition-delay:60ms">
                 <div class="nk-feat__icon" aria-hidden="true">⊘</div>
                 <h3>Без облака и аккаунта</h3>
-                <p>Профили хранятся на Mac. Нет синхронизации, нет телеметрии, нет сервера. История, cookies, URL — не передаются.</p>
+                <p>Профили хранятся на Mac без облачной синхронизации NeAntik. Регистрация не нужна, продуктовая телеметрия отключена.</p>
             </div>
             <div class="card nk-feat nk-reveal" style="transition-delay:120ms">
                 <div class="nk-feat__icon" aria-hidden="true">⊞</div>
@@ -632,23 +645,23 @@
 
     {{-- ═══ HOW IT WORKS ═══ --}}
     <section class="section nk-reveal" id="neantik-how">
-        <div class="section-head"><h2>Четыре шага</h2></div>
+        <div class="section-head"><h2>От нового дела к открытой сессии</h2></div>
         <div class="nk-steps">
             <div class="card nk-step nk-reveal" style="transition-delay:0ms">
                 <h3>Скачайте и установите</h3>
                 <p>Откройте DMG и перетащите NeAntik.app в папку «Программы». ZIP доступен как альтернативный формат.</p>
             </div>
             <div class="card nk-step nk-reveal" style="transition-delay:80ms">
-                <h3>Создайте профиль</h3>
-                <p>Откройте NeAntik. Имя, цвет, стартовая страница — приложение создаст изолированное хранилище.</p>
+                <h3>Назовите своё дело</h3>
+                <p>Создайте профиль и при желании измените предложенное имя. Цвет и стартовый адрес не нужно настраивать для начала работы.</p>
             </div>
             <div class="card nk-step nk-reveal" style="transition-delay:160ms">
-                <h3>Подключите proxy</h3>
-                <p>Direct, HTTP/HTTPS или SOCKS5. Проверьте exit IP, страну и timezone одной кнопкой.</p>
+                <h3>Прокси — если нужен</h3>
+                <p>Вставьте прокси одной строкой или оставьте прямое подключение. NeAntik выполнит подготовку перед запуском; ручная проверка не является обязательным шагом.</p>
             </div>
             <div class="card nk-step nk-reveal" style="transition-delay:240ms">
                 <h3>Запустите браузер</h3>
-                <p>Нажмите «Запустить» — откроется встроенный Chromium с данными, сетью и identity выбранного профиля.</p>
+                <p>Нажмите «Создать и открыть». Встроенный Chromium начнёт с пустой страницы; входы на сайты сохранятся в этом рабочем месте.</p>
             </div>
         </div>
     </section>
@@ -670,17 +683,19 @@
             </div>
             <div class="card nk-privacy-card nk-reveal" style="transition-delay:60ms">
                 <span class="nk-privacy-card__icon nk-privacy-card__icon--muted" aria-hidden="true">NOT SENT</span>
-                <h3>Не передаётся никуда</h3>
+                <h3>Без облачного профиля NeAntik</h3>
                 <ul>
                     <li>Телеметрия отключена</li>
                     <li>Нет облачной синхронизации</li>
                     <li>Нет аналитики использования</li>
                     <li>Нет аккаунта и регистрации</li>
-                    <li>Нет серверов NeAntik</li>
+                    <li>Данные профилей не синхронизируются с NeAntik</li>
                 </ul>
             </div>
         </div>
     </section>
+
+    <p class="muted">При посещении сайтов браузер передаёт им обычные сетевые запросы. Проверка подключения обращается к внешним диагностическим сервисам. Локальное хранение профиля не означает отсутствие сетевого обмена.</p>
 
     {{-- ═══ PROOF ═══ --}}
     <section class="section nk-reveal" id="neantik-proof">

--- a/ops/affpapa/tests/test_bootstrap_release_content.py
+++ b/ops/affpapa/tests/test_bootstrap_release_content.py
@@ -54,7 +54,8 @@ class BootstrapReleaseContentTests(unittest.TestCase):
         self.assertNotIn("Запустить проверку", self.template)
         self.assertNotIn("Запустите A → B → A", self.template)
         self.assertIn("Каждый выпуск проверяется автоматически", self.template)
-        self.assertIn("профиль, proxy, встроенный Chromium", self.template)
+        user_flow = self.template.split('id="neantik-how"', 1)[1].split("{{-- ═══ PRIVACY", 1)[0]
+        self.assertNotIn("A → B → A", user_flow)
 
     def test_landing_does_not_freeze_apple_silicon_generations(self) -> None:
         self.assertNotIn("M1–M4", self.template)


### PR DESCRIPTION
Align the NeAntik landing with the released workplaces workflow. Explain separate persistent sessions, optional pasted proxy, Create and open, and returning to a workplace. Show the 0.5-specific home/menu features only when release metadata is at least 0.5.0.

Replace the overly broad claim that nothing is transmitted with a distinction between local profile storage and ordinary browsing/diagnostic network requests. Label existing SVGs as capability illustrations rather than current-version screenshots.

Validation: 46 AffPapa tests pass; whitespace check passes. The existing audit-flow test now checks the actual user-instruction section rather than freezing one marketing sentence. Live Laravel rendering and publication remain pending restricted site access and administrative installation of the root-owned template. No application/runtime or immutable 0.5.0 assets change.
