### PR TITLE
Release NeAntik 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # NeAntik changelog
 
+## Direct 0.5.2 (32) — September 10, 2026
+
+- A newly created workplace now appears immediately on the Home screen even
+  when the first 24 rows are occupied by pinned workplaces. It is revealed and
+  scrolled into view without changing its pin state or your saved ordering.
+- Keep Home search local to workplace names, tags and notes; proxy endpoints
+  and credentials remain outside the Home search surface.
+- Stabilize the cancellation boundary for proxy-operation tests so the full
+  isolated native suite does not race under parallel load.
+
 ## Direct 0.5.1 (31) — September 10, 2026
 
 - Keep the same workplace home from first launch onward, with one-click creation,

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -23,11 +23,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.1</string>
+	<string>0.5.2</string>
 	<key>CFBundleSignature</key>
 	<string>NANT</string>
 	<key>CFBundleVersion</key>
-	<string>31</string>
+	<string>32</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/NeAntik/ContentView.swift
+++ b/Sources/NeAntik/ContentView.swift
@@ -394,7 +394,7 @@ struct ContentView: View {
 
     @State private var showsWorkplaceHome = true
     @State private var workplaceHomeProjection = WorkplaceHomeProjection(profiles: [], matchCount: 0)
-    @State private var workplaceHomeRevealProfileID: UUID?
+    @State private var homeRevealID: UUID?
 
     private var workspaceBase: some View {
         Group {
@@ -419,7 +419,7 @@ struct ContentView: View {
             if !store.profiles.isEmpty { runtimeReadinessBanner }
             WorkplaceHomeView(
             projection: workplaceHomeProjection,
-            revealProfileID: workplaceHomeRevealProfileID,
+            revealProfileID: homeRevealID,
             isFirstRun: store.profiles.isEmpty,
             runtimeAvailability: runtimeAvailability,
             isCreatingProfile: isCreatingProfileQuickly,
@@ -456,13 +456,13 @@ struct ContentView: View {
         workplaceHomeProjection = WorkplaceHomeProjection.resolve(
             profiles: store.profiles,
             search: profileSearchText,
-            revealProfileID: workplaceHomeRevealProfileID
+            revealProfileID: homeRevealID
         )
     }
 
     private func showWorkplaceCatalog() {
         guard !isWorkspaceModalPresented else { return }
-        workplaceHomeRevealProfileID = nil
+        homeRevealID = nil
         showsWorkplaceHome = false
         profileRouteFilter = .all
         profileOperationalFilter = .all
@@ -472,7 +472,7 @@ struct ContentView: View {
 
     private func showWorkplaceArchive() {
         guard !isWorkspaceModalPresented else { return }
-        workplaceHomeRevealProfileID = nil
+        homeRevealID = nil
         showsWorkplaceHome = false
         resetProfileFilters()
         applyWorkspaceQuery(.default.selecting(scope: .archived))
@@ -480,7 +480,7 @@ struct ContentView: View {
 
     private func showWorkplaceHome() {
         guard !isWorkspaceModalPresented else { return }
-        workplaceHomeRevealProfileID = nil
+        homeRevealID = nil
         showsWorkplaceHome = true
         showsProfileInspector = false
         resetProfileFilters()
@@ -1202,7 +1202,7 @@ struct ContentView: View {
         selection = decision.selectedProfileID
         normalizeSelection(preferred: decision.selectedProfileID)
         if showsWorkplaceHome {
-            workplaceHomeRevealProfileID = decision.selectedProfileID
+            homeRevealID = decision.selectedProfileID
             refreshWorkplaceHome()
         }
     }

--- a/Sources/NeAntik/ContentView.swift
+++ b/Sources/NeAntik/ContentView.swift
@@ -394,6 +394,7 @@ struct ContentView: View {
 
     @State private var showsWorkplaceHome = true
     @State private var workplaceHomeProjection = WorkplaceHomeProjection(profiles: [], matchCount: 0)
+    @State private var workplaceHomeRevealProfileID: UUID?
 
     private var workspaceBase: some View {
         Group {
@@ -418,6 +419,7 @@ struct ContentView: View {
             if !store.profiles.isEmpty { runtimeReadinessBanner }
             WorkplaceHomeView(
             projection: workplaceHomeProjection,
+            revealProfileID: workplaceHomeRevealProfileID,
             isFirstRun: store.profiles.isEmpty,
             runtimeAvailability: runtimeAvailability,
             isCreatingProfile: isCreatingProfileQuickly,
@@ -452,12 +454,15 @@ struct ContentView: View {
 
     private func refreshWorkplaceHome() {
         workplaceHomeProjection = WorkplaceHomeProjection.resolve(
-            profiles: store.profiles, search: profileSearchText
+            profiles: store.profiles,
+            search: profileSearchText,
+            revealProfileID: workplaceHomeRevealProfileID
         )
     }
 
     private func showWorkplaceCatalog() {
         guard !isWorkspaceModalPresented else { return }
+        workplaceHomeRevealProfileID = nil
         showsWorkplaceHome = false
         profileRouteFilter = .all
         profileOperationalFilter = .all
@@ -467,6 +472,7 @@ struct ContentView: View {
 
     private func showWorkplaceArchive() {
         guard !isWorkspaceModalPresented else { return }
+        workplaceHomeRevealProfileID = nil
         showsWorkplaceHome = false
         resetProfileFilters()
         applyWorkspaceQuery(.default.selecting(scope: .archived))
@@ -474,6 +480,7 @@ struct ContentView: View {
 
     private func showWorkplaceHome() {
         guard !isWorkspaceModalPresented else { return }
+        workplaceHomeRevealProfileID = nil
         showsWorkplaceHome = true
         showsProfileInspector = false
         resetProfileFilters()
@@ -1194,6 +1201,10 @@ struct ContentView: View {
         preferredProfileSelection = decision.selectedProfileID
         selection = decision.selectedProfileID
         normalizeSelection(preferred: decision.selectedProfileID)
+        if showsWorkplaceHome {
+            workplaceHomeRevealProfileID = decision.selectedProfileID
+            refreshWorkplaceHome()
+        }
     }
 
     private func clearWorkspaceAlert(

--- a/Sources/NeAntik/WorkplaceHome.swift
+++ b/Sources/NeAntik/WorkplaceHome.swift
@@ -8,7 +8,10 @@ struct WorkplaceHomeProjection: Equatable, Sendable {
     let matchCount: Int
 
     static func resolve(
-        profiles: [BrowserProfile], search: String, limit: Int = 24
+        profiles: [BrowserProfile],
+        search: String,
+        limit: Int = 24,
+        revealProfileID: UUID? = nil
     ) -> Self {
         let query = search.trimmingCharacters(in: .whitespacesAndNewlines)
         let matches = profiles.filter { profile in
@@ -23,10 +26,25 @@ struct WorkplaceHomeProjection: Equatable, Sendable {
             if left != right { return left > right }
             return lhs.id.uuidString < rhs.id.uuidString
         }
-        return Self(
-            profiles: Array(matches.prefix(max(0, limit))),
-            matchCount: matches.count
-        )
+        let effectiveLimit = max(0, limit)
+        var visibleProfiles = Array(matches.prefix(effectiveLimit))
+
+        // A newly created workplace must be visible immediately, even when a
+        // full Home list is headed by pinned workplaces. This is presentation
+        // only: it never changes pinning or the stored ordering.
+        if effectiveLimit > 0,
+           let revealProfileID,
+           let revealedProfile = matches.first(where: { $0.id == revealProfileID }),
+           !visibleProfiles.contains(where: { $0.id == revealProfileID })
+        {
+            if visibleProfiles.isEmpty {
+                visibleProfiles = [revealedProfile]
+            } else {
+                visibleProfiles[visibleProfiles.index(before: visibleProfiles.endIndex)] = revealedProfile
+            }
+        }
+
+        return Self(profiles: visibleProfiles, matchCount: matches.count)
     }
 }
 
@@ -76,6 +94,7 @@ struct WorkplaceOpenPresentation: Equatable, Sendable {
 
 struct WorkplaceHomeView: View {
     let projection: WorkplaceHomeProjection
+    let revealProfileID: UUID?
     let isFirstRun: Bool
     let runtimeAvailability: BrowserRuntimeAvailability
     let isCreatingProfile: Bool
@@ -141,10 +160,12 @@ struct WorkplaceHomeView: View {
                         .help("Очистить поиск")
                     }
                 }
-                ScrollView {
-                    LazyVStack(spacing: 0) {
+                ScrollViewReader { scrollProxy in
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
                         ForEach(projection.profiles) { profile in
                             workplaceRow(profile)
+                                .id(profile.id)
                             Divider()
                         }
                         if projection.matchCount == 0 {
@@ -165,6 +186,13 @@ struct WorkplaceHomeView: View {
                             Button("Все рабочие места (\(projection.matchCount))", action: onCatalog)
                                 .padding(.top, 16)
                         }
+                        }
+                    }
+                    .onAppear {
+                        scrollToRevealedProfile(using: scrollProxy)
+                    }
+                    .onChange(of: revealProfileID) { _, _ in
+                        scrollToRevealedProfile(using: scrollProxy)
                     }
                 }
             }
@@ -178,6 +206,15 @@ struct WorkplaceHomeView: View {
     private func clearSearch() {
         search = ""
         searchFocus.wrappedValue = true
+    }
+
+    private func scrollToRevealedProfile(using proxy: ScrollViewProxy) {
+        guard let revealProfileID,
+              projection.profiles.contains(where: { $0.id == revealProfileID })
+        else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(revealProfileID, anchor: .center)
+        }
     }
 
     private func workplaceRow(_ profile: BrowserProfile) -> some View {

--- a/Tests/NeAntikTests/ProxyTestOperationRegistryTests.swift
+++ b/Tests/NeAntikTests/ProxyTestOperationRegistryTests.swift
@@ -454,14 +454,22 @@ struct ProxyTestOperationRegistryTests {
 }
 
 private actor OwnedProxyBoundaryBarrier {
+    private enum Arrival: Sendable {
+        case reached
+        case finished(String?)
+    }
+
     private var reached = false
     private var released = false
     private var finished = false
     private var completionError: String?
     private var continuation: CheckedContinuation<Void, Never>?
+    private var arrivalContinuation: CheckedContinuation<Arrival, Never>?
 
     func suspend() async {
         reached = true
+        arrivalContinuation?.resume(returning: .reached)
+        arrivalContinuation = nil
         guard !released else { return }
         await withCheckedContinuation { continuation = $0 }
     }
@@ -469,17 +477,32 @@ private actor OwnedProxyBoundaryBarrier {
     func completed(error: String?) {
         finished = true
         completionError = error
+        arrivalContinuation?.resume(returning: .finished(error))
+        arrivalContinuation = nil
     }
 
     func waitUntilReached() async throws {
-        for _ in 0..<2_000 {
-            if reached { return }
-            if finished {
-                throw BoundaryFailure(reason: completionError ?? "Operation exited before boundary")
-            }
-            try await Task.sleep(for: .milliseconds(1))
+        if reached { return }
+        if finished {
+            throw BoundaryFailure(
+                reason: completionError ?? "Operation exited before boundary"
+            )
         }
-        throw BoundaryFailure(reason: "Timed out waiting for operation boundary")
+        let arrival = await withCheckedContinuation {
+            (continuation: CheckedContinuation<Arrival, Never>) in
+            if reached {
+                continuation.resume(returning: .reached)
+            } else if finished {
+                continuation.resume(returning: .finished(completionError))
+            } else {
+                arrivalContinuation = continuation
+            }
+        }
+        if case let .finished(error) = arrival {
+            throw BoundaryFailure(
+                reason: error ?? "Operation exited before boundary"
+            )
+        }
     }
 
     func resume() {

--- a/Tests/NeAntikTests/ResponsiveLayoutRenderTests.swift
+++ b/Tests/NeAntikTests/ResponsiveLayoutRenderTests.swift
@@ -1272,6 +1272,7 @@ private struct WorkplaceHomeRenderFixture: View {
     var body: some View {
         WorkplaceHomeView(
             projection: WorkplaceHomeProjection.resolve(profiles: profiles, search: search),
+            revealProfileID: nil,
             isFirstRun: profiles.isEmpty,
             runtimeAvailability: runtime,
             isCreatingProfile: false,

--- a/Tests/NeAntikTests/WorkplaceHomeTests.swift
+++ b/Tests/NeAntikTests/WorkplaceHomeTests.swift
@@ -26,6 +26,46 @@ struct WorkplaceHomeTests {
         }
     }
 
+    @Test func newlyCreatedPlaceIsVisibleWhenPinnedPlacesFillHome() {
+        let pinned = (0 ..< 24).map { index in
+            BrowserProfile(
+                name: "Pinned \(index)",
+                isPinned: true,
+                createdAt: Date(timeIntervalSince1970: TimeInterval(index))
+            )
+        }
+        let created = BrowserProfile(
+            name: "New workplace",
+            createdAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        let result = WorkplaceHomeProjection.resolve(
+            profiles: pinned + [created],
+            search: "",
+            limit: 24,
+            revealProfileID: created.id
+        )
+
+        #expect(result.matchCount == 25)
+        #expect(result.profiles.count == 24)
+        #expect(result.profiles.contains(where: { $0.id == created.id }))
+        #expect(result.profiles.filter(\.isPinned).count == 23)
+    }
+
+    @Test func revealDoesNotBypassHomeSearchOrArchiveBoundary() {
+        let active = BrowserProfile(name: "Design")
+        let archived = BrowserProfile(name: "Archive", isArchived: true)
+
+        let result = WorkplaceHomeProjection.resolve(
+            profiles: [active, archived],
+            search: "Other",
+            revealProfileID: archived.id
+        )
+
+        #expect(result.profiles.isEmpty)
+        #expect(result.matchCount == 0)
+    }
+
     @Test func openNeverStopsRunningPlaceEvenWithoutRuntime() {
         for state in [BrowserProfileProcessState.managed, .externalVerified, .externalManualOnly] {
             let result = WorkplaceOpenPresentation.resolve(state: state, archived: false, runtime: .missing)


### PR DESCRIPTION
Fix Home visibility after creating a workplace when pinned rows fill the initial list. The new workplace is revealed without altering pinning or stored order. Includes focused Home and responsive-render coverage.