### PR TITLE
NeAntik 0.5.3: show workplace attention on Home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # NeAntik changelog
 
+## Direct 0.5.3 (33) — September 10, 2026
+
+- Home now makes the current state visible without a second dashboard: local
+  quick views show running workplaces, items requiring attention, workplaces
+  without folders and workplaces without tags. Counts never inspect browser
+  data, credentials or proxy endpoints.
+- Running means a confirmed browser process only. Attention reuses existing
+  recovery and credential-free route-health state; opening a quick view never
+  starts a browser, checks a proxy or changes a profile.
+- The Home row menu now offers a bounded folder picker, opens tags directly in
+  the existing validated editor and can create a similar workplace. It reuses
+  the current local store, undo-aware folder move and fresh-identity copy flow.
+
 ## Direct 0.5.2 (32) — September 10, 2026
 
 - A newly created workplace now appears immediately on the Home screen even

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -23,11 +23,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.2</string>
+	<string>0.5.3</string>
 	<key>CFBundleSignature</key>
 	<string>NANT</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/NeAntik/ContentView.swift
+++ b/Sources/NeAntik/ContentView.swift
@@ -393,7 +393,7 @@ struct ContentView: View {
     }
 
     @State private var showsWorkplaceHome = true
-    @State private var workplaceHomeProjection = WorkplaceHomeProjection(profiles: [], matchCount: 0)
+    @State private var workplaceHomeProjection = WorkplaceHomeProjection(profiles: [], matchCount: 0, summary: .empty)
     @State private var homeRevealID: UUID?
 
     private var workspaceBase: some View {
@@ -410,6 +410,8 @@ struct ContentView: View {
         }
         .onChange(of: store.profileListRevision) { _, _ in refreshWorkplaceHome() }
         .onChange(of: profileSearchText) { _, _ in refreshWorkplaceHome() }
+        .onChange(of: processes.processStateRevision) { _, _ in refreshWorkplaceHome() }
+        .onChange(of: proxyHealthCoordinator.healthByProfileID) { _, _ in refreshWorkplaceHome() }
         .onChange(of: workplaceNavigation.pending) { _, _ in handleWorkplaceNavigation() }
         .onChange(of: isWorkspaceModalPresented) { _, value in workplaceNavigation.isBlocked = value }
     }
@@ -456,7 +458,10 @@ struct ContentView: View {
         workplaceHomeProjection = WorkplaceHomeProjection.resolve(
             profiles: store.profiles,
             search: profileSearchText,
-            revealProfileID: homeRevealID
+            revealProfileID: homeRevealID,
+            processState: { processes.processState(for: $0) },
+            proxyHealth: { proxyHealthCoordinator.state(for: $0) },
+            organization: store.organization
         )
     }
 
@@ -1063,7 +1068,6 @@ struct ContentView: View {
                 ?? QuickProfileBootstrap.nextAvailableName(existingProfiles: store.profiles),
             canCreateAndOpen: runtimeAvailability == .ready,
             onCreateAndOpen: { profile, passwordUpdate, folderID in
-                // Persist first; a failed launch must never become a failed save.
                 let saved = try saveProfileEditorDraft(
                     profile, passwordUpdate: passwordUpdate, folderID: folderID,
                     original: request.profile, openedProcessState: request.openedProcessState
@@ -2658,6 +2662,7 @@ struct ContentView: View {
                 _ = processes.focus(profileID: profile.id)
             },
             edit: { beginEditing(profile) },
+            editTags: { beginEditing(profile, focusing: .tags) },
             editNote: { beginEditingNote(profile) },
             togglePinned: {
                 guard !isWorkspaceModalPresented else { return }
@@ -2867,9 +2872,7 @@ struct ContentView: View {
                     preparationReceipt: nil
                 )
             case .prepareProxyContext:
-                // Every browser session gets its own route observation.
-                // A manual health check is useful feedback, not authority to
-                // reuse a potentially rotating endpoint at Start time.
+                // Each launch obtains its own route observation.
                 startAutomaticLaunchPreparation(
                     profile,
                     runtime: runtime
@@ -2924,9 +2927,7 @@ struct ContentView: View {
         try BrowserLaunchStagedPreflight.validate(
             BrowserLaunchPreflightInput(
                 profile: profile,
-                // Presentation can synthesize `.checking` while proxy launch
-                // preparation is in flight. Safety must inspect the actual
-                // process state so a successful preparation can launch.
+                // Safety uses the actual state, not a transient UI state.
                 processState: processes.processState(for: profile.id),
                 runtimePreflight: BrowserRuntimePreflightValidator.validate(
                     runtime

--- a/Sources/NeAntik/ProfileCommands.swift
+++ b/Sources/NeAntik/ProfileCommands.swift
@@ -132,6 +132,7 @@ struct ProfileCommandSet {
     let toggleRunning: () -> Void
     let focusRunning: () -> Void
     let edit: () -> Void
+    let editTags: () -> Void
     let editNote: () -> Void
     let togglePinned: () -> Void
     let duplicate: () -> Void
@@ -148,6 +149,7 @@ struct ProfileCommandSet {
         toggleRunning: {},
         focusRunning: {},
         edit: {},
+        editTags: {},
         editNote: {},
         togglePinned: {},
         duplicate: {},

--- a/Sources/NeAntik/WorkplaceHome.swift
+++ b/Sources/NeAntik/WorkplaceHome.swift
@@ -1,24 +1,141 @@
 import Foundation
 import SwiftUI
 
+/// A transient, local-only way to narrow the Home list. It deliberately does
+/// not become profile metadata or alter the Catalog's composable query state.
+enum WorkplaceHomeQuickFilter: String, CaseIterable, Identifiable, Sendable {
+    case all
+    case running
+    case attention
+    case unfiled
+    case untagged
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .all: "Все"
+        case .running: "Запущено"
+        case .attention: "Требуют внимания"
+        case .unfiled: "Без папки"
+        case .untagged: "Без тегов"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .all: "rectangle.stack"
+        case .running: "play.circle.fill"
+        case .attention: "exclamationmark.triangle.fill"
+        case .unfiled: "folder.badge.questionmark"
+        case .untagged: "tag.slash"
+        }
+    }
+
+    var emptyTitle: String {
+        switch self {
+        case .all: "Нет активных рабочих мест"
+        case .running: "Нет запущенных рабочих мест"
+        case .attention: "Всё в порядке"
+        case .unfiled: "Все рабочие места распределены по папкам"
+        case .untagged: "У всех рабочих мест есть теги"
+        }
+    }
+
+    var emptyMessage: String {
+        switch self {
+        case .all: "Рабочие места в архиве сохраняют ваши данные. Их можно вернуть и продолжить работу."
+        case .running: "Открой рабочее место — оно появится здесь."
+        case .attention: "Нет ошибок подключения и состояний, требующих действия."
+        case .unfiled: "Новые рабочие места без папки появляются в этом списке."
+        case .untagged: "Теги помогают быстрее находить рабочие места."
+        }
+    }
+}
+
+struct WorkplaceHomeSummary: Equatable, Sendable {
+    let activeCount: Int
+    let runningCount: Int
+    let attentionCount: Int
+    let unfiledCount: Int
+    let untaggedCount: Int
+
+    static let empty = Self(
+        activeCount: 0,
+        runningCount: 0,
+        attentionCount: 0,
+        unfiledCount: 0,
+        untaggedCount: 0
+    )
+
+    func count(for filter: WorkplaceHomeQuickFilter) -> Int {
+        switch filter {
+        case .all: activeCount
+        case .running: runningCount
+        case .attention: attentionCount
+        case .unfiled: unfiledCount
+        case .untagged: untaggedCount
+        }
+    }
+}
+
 /// A view of existing profiles, never another profile store. No browser data or
 /// credentials are inspected to build the home screen.
 struct WorkplaceHomeProjection: Equatable, Sendable {
     let profiles: [BrowserProfile]
     let matchCount: Int
+    let summary: WorkplaceHomeSummary
+    private let matchesByQuickFilter: [WorkplaceHomeQuickFilter: [BrowserProfile]]
+
+    init(
+        profiles: [BrowserProfile],
+        matchCount: Int,
+        summary: WorkplaceHomeSummary = .empty,
+        matchesByQuickFilter: [WorkplaceHomeQuickFilter: [BrowserProfile]] = [:]
+    ) {
+        self.profiles = profiles
+        self.matchCount = matchCount
+        self.summary = summary
+        self.matchesByQuickFilter = matchesByQuickFilter.isEmpty
+            ? [.all: profiles]
+            : matchesByQuickFilter
+    }
 
     static func resolve(
         profiles: [BrowserProfile],
         search: String,
         limit: Int = 24,
-        revealProfileID: UUID? = nil
+        revealProfileID: UUID? = nil,
+        processState: (UUID) -> BrowserProfileProcessState = { _ in .stopped },
+        proxyHealth: (BrowserProfile) -> ProxyHealthState? = { _ in nil },
+        organization: ProfileOrganizationState = .empty
     ) -> Self {
         let query = search.trimmingCharacters(in: .whitespacesAndNewlines)
-        let matches = profiles.filter { profile in
-            !profile.isArchived && (query.isEmpty ||
-                ([profile.name, profile.note] + profile.tags).contains {
-                    $0.localizedStandardContains(query)
-                })
+        let activeProfiles = profiles.filter { !$0.isArchived }
+        let operational = ProfileOperationalProjection.resolve(
+            profiles: activeProfiles,
+            processState: processState,
+            proxyHealth: proxyHealth
+        )
+        let unfiledIDs = Set(activeProfiles.compactMap { profile in
+            organization.folder(withID: organization.folderID(forProfileID: profile.id)) == nil
+                ? profile.id
+                : nil
+        })
+        let untaggedIDs = Set(activeProfiles.compactMap { profile in
+            profile.tags.isEmpty ? profile.id : nil
+        })
+        let summary = WorkplaceHomeSummary(
+            activeCount: activeProfiles.count,
+            runningCount: operational.runningProfileIDs.count,
+            attentionCount: operational.attentionProfileIDs.count,
+            unfiledCount: unfiledIDs.count,
+            untaggedCount: untaggedIDs.count
+        )
+        let matches = activeProfiles.filter { profile in
+            query.isEmpty || ([profile.name, profile.note] + profile.tags).contains {
+                $0.localizedStandardContains(query)
+            }
         }.sorted { lhs, rhs in
             if lhs.isPinned != rhs.isPinned { return lhs.isPinned }
             let left = lhs.lastLaunchedAt ?? lhs.createdAt
@@ -26,25 +143,63 @@ struct WorkplaceHomeProjection: Equatable, Sendable {
             if left != right { return left > right }
             return lhs.id.uuidString < rhs.id.uuidString
         }
+        let matchesByQuickFilter = Dictionary(
+            uniqueKeysWithValues: WorkplaceHomeQuickFilter.allCases.map { filter in
+                (filter, matches.filter { profile in
+                    switch filter {
+                    case .all: true
+                    case .running: operational.runningProfileIDs.contains(profile.id)
+                    case .attention: operational.attentionProfileIDs.contains(profile.id)
+                    case .unfiled: unfiledIDs.contains(profile.id)
+                    case .untagged: untaggedIDs.contains(profile.id)
+                    }
+                })
+            }
+        )
+        let visibleProfiles = visibleProfiles(
+            matches: matches, limit: limit, revealProfileID: revealProfileID
+        )
+
+        return Self(
+            profiles: visibleProfiles,
+            matchCount: matches.count,
+            summary: summary,
+            matchesByQuickFilter: matchesByQuickFilter
+        )
+    }
+
+    func profiles(
+        for quickFilter: WorkplaceHomeQuickFilter,
+        limit: Int = 24,
+        revealProfileID: UUID? = nil
+    ) -> [BrowserProfile] {
+        Self.visibleProfiles(
+            matches: matchesByQuickFilter[quickFilter] ?? [],
+            limit: limit,
+            revealProfileID: revealProfileID
+        )
+    }
+
+    func matchCount(for quickFilter: WorkplaceHomeQuickFilter) -> Int {
+        (matchesByQuickFilter[quickFilter] ?? []).count
+    }
+
+    private static func visibleProfiles(
+        matches: [BrowserProfile],
+        limit: Int,
+        revealProfileID: UUID?
+    ) -> [BrowserProfile] {
         let effectiveLimit = max(0, limit)
         var visibleProfiles = Array(matches.prefix(effectiveLimit))
-
-        // A newly created workplace must be visible immediately, even when a
-        // full Home list is headed by pinned workplaces. This is presentation
-        // only: it never changes pinning or the stored ordering.
         if effectiveLimit > 0,
            let revealProfileID,
-           let revealedProfile = matches.first(where: { $0.id == revealProfileID }),
+           let revealed = matches.first(where: { $0.id == revealProfileID }),
            !visibleProfiles.contains(where: { $0.id == revealProfileID })
         {
-            if visibleProfiles.isEmpty {
-                visibleProfiles = [revealedProfile]
-            } else {
-                visibleProfiles[visibleProfiles.index(before: visibleProfiles.endIndex)] = revealedProfile
-            }
+            if visibleProfiles.isEmpty { visibleProfiles = [revealed] }
+            else { visibleProfiles[visibleProfiles.index(before: visibleProfiles.endIndex)] = revealed }
         }
-
-        return Self(profiles: visibleProfiles, matchCount: matches.count)
+        return visibleProfiles
     }
 }
 
@@ -111,8 +266,13 @@ struct WorkplaceHomeView: View {
     let onRetryRuntimeCheck: () -> Void
     let onArchive: () -> Void
     var notice: (BrowserProfile) -> String? = { _ in nil }
+    @State private var quickFilter: WorkplaceHomeQuickFilter = .all
 
     var body: some View {
+        let profiles = projection.profiles(
+            for: quickFilter, revealProfileID: revealProfileID
+        )
+        let matchCount = projection.matchCount(for: quickFilter)
         VStack(alignment: .leading, spacing: 20) {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: 5) {
@@ -147,7 +307,7 @@ struct WorkplaceHomeView: View {
                             }
                         }
                         .onSubmit {
-                            if projection.matchCount == 1, let profile = projection.profiles.first {
+                            if matchCount == 1, let profile = profiles.first {
                                 onOpen(profile)
                             }
                         }
@@ -160,20 +320,27 @@ struct WorkplaceHomeView: View {
                         .help("Очистить поиск")
                     }
                 }
+                quickFilterBar
                 ScrollViewReader { scrollProxy in
                     ScrollView {
                         LazyVStack(spacing: 0) {
-                        ForEach(projection.profiles) { profile in
+                        ForEach(profiles) { profile in
                             workplaceRow(profile)
                                 .id(profile.id)
                             Divider()
                         }
-                        if projection.matchCount == 0 {
+                        if matchCount == 0 {
                             if search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                                ContentUnavailableView("Нет активных рабочих мест",
-                                    systemImage: "square.grid.2x2",
-                                    description: Text("Рабочие места в архиве сохраняют ваши данные. Их можно вернуть и продолжить работу."))
-                                Button("Открыть архив", systemImage: "archivebox", action: onArchive)
+                                ContentUnavailableView(
+                                    quickFilter.emptyTitle,
+                                    systemImage: quickFilter.systemImage,
+                                    description: Text(quickFilter.emptyMessage)
+                                )
+                                if quickFilter == .all {
+                                    Button("Открыть архив", systemImage: "archivebox", action: onArchive)
+                                } else {
+                                    Button("Показать все", action: { quickFilter = .all })
+                                }
                             } else {
                                 ContentUnavailableView("Ничего не найдено",
                                     systemImage: "magnifyingglass",
@@ -182,8 +349,8 @@ struct WorkplaceHomeView: View {
                                 Button("Очистить поиск", action: clearSearch)
                             }
                         }
-                        if projection.matchCount > projection.profiles.count {
-                            Button("Все рабочие места (\(projection.matchCount))", action: onCatalog)
+                        if matchCount > profiles.count {
+                            Button("Все рабочие места (\(matchCount))", action: onCatalog)
                                 .padding(.top, 16)
                         }
                         }
@@ -208,9 +375,67 @@ struct WorkplaceHomeView: View {
         searchFocus.wrappedValue = true
     }
 
+    @ViewBuilder
+    private var quickFilterBar: some View {
+        let filters = WorkplaceHomeQuickFilter.allCases.filter {
+            $0 == .all || projection.summary.count(for: $0) > 0 || $0 == quickFilter
+        }
+        if filters.count > 1 || quickFilter != .all {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 7) {
+                    ForEach(filters) { filter in
+                        quickFilterButton(filter)
+                    }
+                }
+            }
+            .accessibilityLabel("Состояние рабочих мест")
+        }
+    }
+
+    private func quickFilterButton(
+        _ filter: WorkplaceHomeQuickFilter
+    ) -> some View {
+        let selected = filter == quickFilter
+        let count = projection.summary.count(for: filter)
+        return Button {
+            quickFilter = filter
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: filter.systemImage)
+                    .accessibilityHidden(true)
+                Text(filter.title)
+                Text("\(count)")
+                    .font(.caption2.monospacedDigit())
+            }
+            .font(.caption.weight(selected ? .semibold : .regular))
+            .padding(.horizontal, 9)
+            .frame(minHeight: 28)
+            .background(
+                (filter == .attention ? Color.orange : Color.accentColor)
+                    .opacity(selected ? 0.18 : 0.07),
+                in: Capsule()
+            )
+            .overlay {
+                Capsule().stroke(
+                    selected
+                        ? (filter == .attention ? Color.orange : Color.accentColor).opacity(0.55)
+                        : Color.clear,
+                    lineWidth: 1
+                )
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(filter.title): \(count)")
+        .accessibilityValue(selected ? "Выбрано" : "Не выбрано")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
     private func scrollToRevealedProfile(using proxy: ScrollViewProxy) {
         guard let revealProfileID,
-              projection.profiles.contains(where: { $0.id == revealProfileID })
+              projection.profiles(
+                  for: quickFilter,
+                  revealProfileID: revealProfileID
+              ).contains(where: { $0.id == revealProfileID })
         else { return }
         DispatchQueue.main.async {
             proxy.scrollTo(revealProfileID, anchor: .center)
@@ -267,6 +492,29 @@ struct WorkplaceHomeView: View {
                 Button(commands.presentation.pinTitle,
                        systemImage: commands.presentation.pinSystemImage,
                        action: commands.togglePinned)
+                Menu("Папка", systemImage: "folder") {
+                    ForEach(commands.folderOptions) { option in
+                        Button {
+                            commands.moveToFolder(option.folderID)
+                        } label: {
+                            Label(
+                                option.title,
+                                systemImage: option.isSelected
+                                    ? "checkmark"
+                                    : "folder"
+                            )
+                        }
+                        .disabled(option.isSelected)
+                    }
+                    if commands.hasMoreFolderOptions {
+                        Divider()
+                        Button("Выбрать папку…", action: commands.chooseFolder)
+                    }
+                }
+                Button("Теги…", systemImage: "tag", action: commands.editTags)
+                    .disabled(!commands.presentation.editIsEnabled)
+                Button("Создать похожее", systemImage: "plus.square.on.square", action: commands.duplicate)
+                    .disabled(!commands.presentation.editIsEnabled)
                 Button("Изменить…", systemImage: "pencil", action: commands.edit)
                     .disabled(!commands.presentation.editIsEnabled)
                 Button("Сведения", systemImage: "info.circle") { onInspect(profile) }

--- a/Tests/NeAntikTests/WorkplaceHomeTests.swift
+++ b/Tests/NeAntikTests/WorkplaceHomeTests.swift
@@ -66,6 +66,68 @@ struct WorkplaceHomeTests {
         #expect(result.matchCount == 0)
     }
 
+    @Test func quickViewsStayLocalAndClassifyOnlyActionableState() {
+        let folder = ProfileFolder(name: "Клиенты")
+        let running = BrowserProfile(name: "Running", tags: ["Оплата"])
+        let recovery = BrowserProfile(name: "Recovery")
+        let checking = BrowserProfile(name: "Checking")
+        let unfiled = BrowserProfile(name: "Loose", tags: ["Личное"])
+        let archived = BrowserProfile(name: "Archive", isArchived: true)
+        let organization = ProfileOrganizationState(
+            folders: [folder],
+            assignmentsByProfileID: [running.id: folder.id]
+        )
+        let states: [UUID: BrowserProfileProcessState] = [
+            running.id: .managed,
+            recovery.id: .recoveryRequired,
+            checking.id: .checking,
+        ]
+
+        let result = WorkplaceHomeProjection.resolve(
+            profiles: [running, recovery, checking, unfiled, archived],
+            search: "",
+            processState: { states[$0] ?? .stopped },
+            organization: organization
+        )
+
+        #expect(result.summary.activeCount == 4)
+        #expect(result.summary.runningCount == 1)
+        #expect(result.summary.attentionCount == 1)
+        #expect(result.summary.unfiledCount == 3)
+        #expect(result.summary.untaggedCount == 2)
+        #expect(result.profiles(for: .running).map(\.id) == [running.id])
+        #expect(result.profiles(for: .attention).map(\.id) == [recovery.id])
+        #expect(Set(result.profiles(for: .unfiled).map(\.id)) == [recovery.id, checking.id, unfiled.id])
+        #expect(Set(result.profiles(for: .untagged).map(\.id)) == [recovery.id, checking.id])
+        #expect(!result.profiles(for: .all).contains(where: { $0.id == archived.id }))
+    }
+
+    @Test func quickViewsReadOperationalStateOncePerActiveWorkplace() {
+        let places = (0..<2_000).map { index in
+            BrowserProfile(name: "Place \(index)")
+        }
+        var processReads = 0
+        var proxyReads = 0
+
+        let result = WorkplaceHomeProjection.resolve(
+            profiles: places,
+            search: "",
+            processState: { _ in
+                processReads += 1
+                return .stopped
+            },
+            proxyHealth: { _ in
+                proxyReads += 1
+                return nil
+            }
+        )
+
+        #expect(result.summary.activeCount == places.count)
+        #expect(result.matchCount(for: .all) == places.count)
+        #expect(processReads == places.count)
+        #expect(proxyReads == places.count)
+    }
+
     @Test func openNeverStopsRunningPlaceEvenWithoutRuntime() {
         for state in [BrowserProfileProcessState.managed, .externalVerified, .externalManualOnly] {
             let result = WorkplaceOpenPresentation.resolve(state: state, archived: false, runtime: .missing)


### PR DESCRIPTION
Home now exposes local quick views for running, attention, unfiled and untagged workplaces. The row menu reuses existing safe folder, tag-editor and fresh-identity duplication commands.\n\nValidation: full isolated native Swift suite, responsive Home renders, source budget, recommendation matrix and AffPapa snapshot tests.