### PR TITLE
NeAntik 0.5.4: faster Home and durable proxy health storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # NeAntik changelog
 
+## Direct 0.5.4 (34) — September 10, 2026
+
+- Make Home search faster on large local workplace lists: the sorted index and
+  existing operational state are reused while you type, and quick-view counts
+  always match the visible search result.
+- Keep the menu lightweight by projecting only the eight recent workplaces it
+  needs. Resolving a newer browser runtime can no longer let an older result
+  overwrite it.
+- Open tags directly when Home requests them, including keyboard focus in the
+  advanced editor section.
+- Store coarse local proxy-health observations through a descriptor-bound,
+  owner-only write path with durable file and directory commits.
+
 ## Direct 0.5.3 (33) — September 10, 2026
 
 - Home now makes the current state visible without a second dashboard: local

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -23,11 +23,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.3</string>
+	<string>0.5.4</string>
 	<key>CFBundleSignature</key>
 	<string>NANT</string>
 	<key>CFBundleVersion</key>
-	<string>33</string>
+	<string>34</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/NeAntik/ContentView.swift
+++ b/Sources/NeAntik/ContentView.swift
@@ -27,10 +27,11 @@ struct ContentView: View {
     @State private var showingDeleteConfirmation = false
     @State private var showingReleaseFingerprintAudit = false
     @State private var localError: String?
-    @State private var launchPreparationFailure: LaunchPreparationFailure?
+    @State private var launchIssue: LaunchPreparationFailure?
     @State private var forceStopRequest: BrowserProfile?
     @State private var resolvedRuntime: BrowserRuntime?
     @State private var isResolvingRuntime = true
+    @State private var runtimeState = RuntimeResolutionState()
     @State private var clipboardLease = ClipboardLeaseState()
     @State private var clipboardNotice: ClipboardNotice?
     @State private var clipboardClearTask: Task<Void, Never>?
@@ -141,7 +142,7 @@ struct ContentView: View {
             showingReleaseFingerprintAudit ||
             showingDeleteConfirmation ||
             folderPendingDelete != nil ||
-            launchPreparationFailure != nil
+            launchIssue != nil
     }
 
     private var workspaceCommandSet: WorkspaceCommandSet {
@@ -394,6 +395,7 @@ struct ContentView: View {
 
     @State private var showsWorkplaceHome = true
     @State private var workplaceHomeProjection = WorkplaceHomeProjection(profiles: [], matchCount: 0, summary: .empty)
+    @State private var homeResolver = WorkplaceHomeStateResolver()
     @State private var homeRevealID: UUID?
 
     private var workspaceBase: some View {
@@ -455,13 +457,16 @@ struct ContentView: View {
     }
 
     private func refreshWorkplaceHome() {
-        workplaceHomeProjection = WorkplaceHomeProjection.resolve(
+        workplaceHomeProjection = homeResolver.resolve(
+            profileRevision: store.profileListRevision,
+            processRevision: processes.processStateRevision,
+            healthRecords: proxyHealthCoordinator.healthByProfileID,
             profiles: store.profiles,
+            organization: store.organization,
             search: profileSearchText,
             revealProfileID: homeRevealID,
             processState: { processes.processState(for: $0) },
-            proxyHealth: { proxyHealthCoordinator.state(for: $0) },
-            organization: store.organization
+            proxyHealth: { proxyHealthCoordinator.state(for: $0) }
         )
     }
 
@@ -826,33 +831,33 @@ struct ContentView: View {
             )
         }
         .alert(
-            launchPreparationFailure?.title ?? "Не удалось запустить",
+            launchIssue?.title ?? "Не удалось запустить",
             isPresented: Binding(
-                get: { launchPreparationFailure != nil },
+                get: { launchIssue != nil },
                 set: { visible in
                     if !visible {
-                        launchPreparationFailure = nil
+                        launchIssue = nil
                     }
                 }
             ),
-            presenting: launchPreparationFailure
+            presenting: launchIssue
         ) { failure in
             Button("Повторить") {
-                launchPreparationFailure = nil
+                launchIssue = nil
                 if let profile = store.profile(withID: failure.profileID) {
                     launch(profile)
                 }
             }
             if failure.offersProxyEdit {
                 Button("Изменить прокси…") {
-                    launchPreparationFailure = nil
+                    launchIssue = nil
                     if let profile = store.profile(withID: failure.profileID) {
                         beginEditing(profile, focusing: .proxyImport)
                     }
                 }
             }
             Button("Отмена", role: .cancel) {
-                launchPreparationFailure = nil
+                launchIssue = nil
             }
         } message: { failure in
             Text(failure.message)
@@ -2872,14 +2877,13 @@ struct ContentView: View {
                     preparationReceipt: nil
                 )
             case .prepareProxyContext:
-                // Each launch obtains its own route observation.
                 startAutomaticLaunchPreparation(
                     profile,
                     runtime: runtime
                 )
             }
         } catch {
-            launchPreparationFailure = LaunchPreparationFailure(
+            launchIssue = LaunchPreparationFailure(
                 profileID: profile.id,
                 message: error.localizedDescription,
                 title: "Браузер не запустился",
@@ -2927,7 +2931,6 @@ struct ContentView: View {
         try BrowserLaunchStagedPreflight.validate(
             BrowserLaunchPreflightInput(
                 profile: profile,
-                // Safety uses the actual state, not a transient UI state.
                 processState: processes.processState(for: profile.id),
                 runtimePreflight: BrowserRuntimePreflightValidator.validate(
                     runtime
@@ -2945,7 +2948,7 @@ struct ContentView: View {
     ) {
         guard !launchOperations.isActive(profile.id) else { return }
         guard !isProxyTestInFlight(profileID: profile.id) else {
-            launchPreparationFailure = LaunchPreparationFailure(
+            launchIssue = LaunchPreparationFailure(
                 profileID: profile.id,
                 message:
                     "Прокси уже проверяется в другом окне. Дождись завершения или отмени проверку там."
@@ -2958,7 +2961,7 @@ struct ContentView: View {
             defer { launchOperations.finish(launchToken) }
             guard !Task.isCancelled, launchOperations.isCurrent(launchToken) else { return }
             guard let token = beginProxyTest(for: profile) else {
-                launchPreparationFailure = LaunchPreparationFailure(
+            launchIssue = LaunchPreparationFailure(
                     profileID: profile.id,
                     message:
                         "Не удалось начать подготовку прокси. Повтори запуск."
@@ -2976,14 +2979,14 @@ struct ContentView: View {
                 let message = localError ??
                     "Подготовка прокси уже выполняется в другом окне."
                 localError = nil
-                launchPreparationFailure = LaunchPreparationFailure(
+            launchIssue = LaunchPreparationFailure(
                     profileID: profile.id,
                     message: message
                 )
                 return
             }
             guard state.latestAttempt.outcome == .succeeded else {
-                launchPreparationFailure = LaunchPreparationFailure(
+            launchIssue = LaunchPreparationFailure(
                     profileID: profile.id,
                     message: NeAntikError.proxyTestFailed(
                         state.latestAttempt.outcome.userSummary
@@ -2994,7 +2997,7 @@ struct ContentView: View {
             guard let currentProfile = store.profile(withID: profile.id),
                   currentProfile.proxy == profile.proxy
             else {
-                launchPreparationFailure = LaunchPreparationFailure(
+            launchIssue = LaunchPreparationFailure(
                     profileID: profile.id,
                     message:
                         "Профиль изменился во время подготовки. Проверь прокси и повтори запуск."
@@ -3009,7 +3012,7 @@ struct ContentView: View {
                 proxyHealth: currentHealth
             ) == .launchImmediately
             else {
-                launchPreparationFailure = LaunchPreparationFailure(
+            launchIssue = LaunchPreparationFailure(
                     profileID: profile.id,
                     message:
                         "Прокси отвечает, но его часовой пояс и язык не удалось безопасно согласовать с профилем."
@@ -3027,7 +3030,7 @@ struct ContentView: View {
                         )
                 )
             } catch {
-                launchPreparationFailure = LaunchPreparationFailure(
+            launchIssue = LaunchPreparationFailure(
                     profileID: currentProfile.id,
                     message:
                         "Прокси подготовлен, но браузер не запустился. " +
@@ -3041,12 +3044,15 @@ struct ContentView: View {
     }
 
     private func resolveRuntime() async {
+        let generation = runtimeState.begin()
         isResolvingRuntime = true
         let locator = runtimeLocator
         let value = await Task.detached(priority: .userInitiated) {
             locator.preferredRuntime()
         }.value
-        guard !Task.isCancelled else {
+        guard !Task.isCancelled,
+              runtimeState.isCurrent(generation)
+        else {
             return
         }
         resolvedRuntime = value

--- a/Sources/NeAntik/ProfileEditorView.swift
+++ b/Sources/NeAntik/ProfileEditorView.swift
@@ -134,6 +134,12 @@ enum ProfileEditorAdvancedPresentation {
   }
 }
 
+enum ProfileEditorInitialPresentation {
+  static func showsAdvancedOptions(initialFocus: ProfileEditorField?, requested: Bool) -> Bool {
+    requested || [.tags, .startURL].contains(initialFocus)
+  }
+}
+
 struct ProfileEditorView: View {
   let original: BrowserProfile?
   let keychain: KeychainStore
@@ -214,7 +220,7 @@ struct ProfileEditorView: View {
     self.onCreateAndOpen = onCreateAndOpen
     self.initialFocus = initialFocus
     _showsAdvancedOptions = State(
-      initialValue: showsAdvancedOptionsInitially
+      initialValue: ProfileEditorInitialPresentation.showsAdvancedOptions(initialFocus: initialFocus, requested: showsAdvancedOptionsInitially)
     )
 
     let profile = original ?? BrowserProfile(name: initialName)
@@ -832,7 +838,9 @@ struct ProfileEditorView: View {
           tags: $editorDraft.tags,
           input: $pendingTagInput,
           suggestions: suggestedTags,
-          focusRequest: validationIssue?.field == .tags ? validationNavigationRequest : 0
+          focusRequest: validationIssue?.field == .tags
+            ? validationNavigationRequest
+            : (initialFocus == .tags ? 1 : 0)
         )
         .id(ProfileEditorField.tags)
         validationLabel(for: .tags)

--- a/Sources/NeAntik/ProxyHealth.swift
+++ b/Sources/NeAntik/ProxyHealth.swift
@@ -239,6 +239,7 @@ enum ProxyHealthStoreError: LocalizedError, Equatable {
     case unsupportedSchema
     case unsafePath
     case capacityExceeded
+    case writeFailed
 
     var errorDescription: String? {
         switch self {
@@ -250,6 +251,8 @@ enum ProxyHealthStoreError: LocalizedError, Equatable {
                 "открыть."
         case .capacityExceeded:
             "История проверок прокси достигла безопасного лимита."
+        case .writeFailed:
+            "Историю проверок прокси не удалось надёжно сохранить."
         }
     }
 }
@@ -539,11 +542,94 @@ actor ProxyHealthStore {
         guard data.count <= Self.maximumFileBytes else {
             throw ProxyHealthStoreError.capacityExceeded
         }
-        try data.write(to: fileURL, options: .atomic)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: fileURL.path
-        )
+        try replacePrivateFile(data, at: fileURL)
+    }
+
+    nonisolated private static func replacePrivateFile(
+        _ data: Data,
+        at fileURL: URL
+    ) throws {
+        let parent = fileURL.deletingLastPathComponent()
+        let name = fileURL.lastPathComponent
+        guard !name.isEmpty, name != ".", name != ".." else {
+            throw ProxyHealthStoreError.unsafePath
+        }
+        let parentDescriptor = parent.path.withCString {
+            Darwin.open($0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        }
+        guard parentDescriptor >= 0 else {
+            throw ProxyHealthStoreError.unsafePath
+        }
+        defer { _ = Darwin.close(parentDescriptor) }
+
+        var parentStatus = stat()
+        guard Darwin.fstat(parentDescriptor, &parentStatus) == 0,
+              parentStatus.st_uid == geteuid(),
+              parentStatus.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR)
+        else {
+            throw ProxyHealthStoreError.unsafePath
+        }
+        guard Darwin.fchmod(parentDescriptor, mode_t(S_IRWXU)) == 0 else {
+            throw ProxyHealthStoreError.writeFailed
+        }
+        var existingStatus = stat()
+        let existingResult = name.withCString {
+            Darwin.fstatat(parentDescriptor, $0, &existingStatus, AT_SYMLINK_NOFOLLOW)
+        }
+        guard existingResult == 0 || errno == ENOENT else {
+            throw ProxyHealthStoreError.writeFailed
+        }
+        if existingResult == 0,
+           (existingStatus.st_mode & mode_t(S_IFMT)) != mode_t(S_IFREG) {
+            throw ProxyHealthStoreError.unsafePath
+        }
+
+        let temporaryName = ".\(name).\(UUID().uuidString).tmp"
+        let descriptor = temporaryName.withCString {
+            Darwin.openat(
+                parentDescriptor,
+                $0,
+                O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+                mode_t(S_IRUSR | S_IWUSR)
+            )
+        }
+        guard descriptor >= 0 else { throw ProxyHealthStoreError.writeFailed }
+        var committed = false
+        defer {
+            _ = Darwin.close(descriptor)
+            if !committed {
+                _ = temporaryName.withCString { Darwin.unlinkat(parentDescriptor, $0, 0) }
+            }
+        }
+        var temporaryStatus = stat()
+        guard Darwin.fstat(descriptor, &temporaryStatus) == 0,
+              temporaryStatus.st_uid == geteuid(),
+              temporaryStatus.st_nlink == 1,
+              temporaryStatus.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG)
+        else {
+            throw ProxyHealthStoreError.unsafePath
+        }
+        try data.withUnsafeBytes { buffer in
+            guard var pointer = buffer.baseAddress else { return }
+            var remaining = buffer.count
+            while remaining > 0 {
+                let written = Darwin.write(descriptor, pointer, remaining)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    throw ProxyHealthStoreError.writeFailed
+                }
+                guard written > 0 else { throw ProxyHealthStoreError.writeFailed }
+                pointer = pointer.advanced(by: written)
+                remaining -= written
+            }
+        }
+        guard Darwin.fsync(descriptor) == 0,
+              temporaryName.withCString({ Darwin.renameat(parentDescriptor, $0, parentDescriptor, name) }) == 0,
+              Darwin.fsync(parentDescriptor) == 0
+        else {
+            throw ProxyHealthStoreError.writeFailed
+        }
+        committed = true
     }
 
     nonisolated private static func entryStatus(

--- a/Sources/NeAntik/RuntimeResolutionState.swift
+++ b/Sources/NeAntik/RuntimeResolutionState.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct RuntimeResolutionState: Equatable, Sendable {
+    private(set) var generation: UInt64 = 0
+
+    mutating func begin() -> UInt64 {
+        generation &+= 1
+        return generation
+    }
+
+    func isCurrent(_ candidate: UInt64) -> Bool {
+        candidate == generation
+    }
+}

--- a/Sources/NeAntik/WorkplaceHome.swift
+++ b/Sources/NeAntik/WorkplaceHome.swift
@@ -110,61 +110,20 @@ struct WorkplaceHomeProjection: Equatable, Sendable {
         proxyHealth: (BrowserProfile) -> ProxyHealthState? = { _ in nil },
         organization: ProfileOrganizationState = .empty
     ) -> Self {
-        let query = search.trimmingCharacters(in: .whitespacesAndNewlines)
-        let activeProfiles = profiles.filter { !$0.isArchived }
+        let index = WorkplaceHomeIndex(
+            profiles: profiles,
+            organization: organization
+        )
         let operational = ProfileOperationalProjection.resolve(
-            profiles: activeProfiles,
+            profiles: index.orderedActiveProfiles,
             processState: processState,
             proxyHealth: proxyHealth
         )
-        let unfiledIDs = Set(activeProfiles.compactMap { profile in
-            organization.folder(withID: organization.folderID(forProfileID: profile.id)) == nil
-                ? profile.id
-                : nil
-        })
-        let untaggedIDs = Set(activeProfiles.compactMap { profile in
-            profile.tags.isEmpty ? profile.id : nil
-        })
-        let summary = WorkplaceHomeSummary(
-            activeCount: activeProfiles.count,
-            runningCount: operational.runningProfileIDs.count,
-            attentionCount: operational.attentionProfileIDs.count,
-            unfiledCount: unfiledIDs.count,
-            untaggedCount: untaggedIDs.count
-        )
-        let matches = activeProfiles.filter { profile in
-            query.isEmpty || ([profile.name, profile.note] + profile.tags).contains {
-                $0.localizedStandardContains(query)
-            }
-        }.sorted { lhs, rhs in
-            if lhs.isPinned != rhs.isPinned { return lhs.isPinned }
-            let left = lhs.lastLaunchedAt ?? lhs.createdAt
-            let right = rhs.lastLaunchedAt ?? rhs.createdAt
-            if left != right { return left > right }
-            return lhs.id.uuidString < rhs.id.uuidString
-        }
-        let matchesByQuickFilter = Dictionary(
-            uniqueKeysWithValues: WorkplaceHomeQuickFilter.allCases.map { filter in
-                (filter, matches.filter { profile in
-                    switch filter {
-                    case .all: true
-                    case .running: operational.runningProfileIDs.contains(profile.id)
-                    case .attention: operational.attentionProfileIDs.contains(profile.id)
-                    case .unfiled: unfiledIDs.contains(profile.id)
-                    case .untagged: untaggedIDs.contains(profile.id)
-                    }
-                })
-            }
-        )
-        let visibleProfiles = visibleProfiles(
-            matches: matches, limit: limit, revealProfileID: revealProfileID
-        )
-
-        return Self(
-            profiles: visibleProfiles,
-            matchCount: matches.count,
-            summary: summary,
-            matchesByQuickFilter: matchesByQuickFilter
+        return index.resolve(
+            search: search,
+            operational: operational,
+            limit: limit,
+            revealProfileID: revealProfileID
         )
     }
 
@@ -184,7 +143,7 @@ struct WorkplaceHomeProjection: Equatable, Sendable {
         (matchesByQuickFilter[quickFilter] ?? []).count
     }
 
-    private static func visibleProfiles(
+    static func visibleProfiles(
         matches: [BrowserProfile],
         limit: Int,
         revealProfileID: UUID?
@@ -396,7 +355,7 @@ struct WorkplaceHomeView: View {
         _ filter: WorkplaceHomeQuickFilter
     ) -> some View {
         let selected = filter == quickFilter
-        let count = projection.summary.count(for: filter)
+        let count = projection.matchCount(for: filter)
         return Button {
             quickFilter = filter
         } label: {

--- a/Sources/NeAntik/WorkplaceHomeIndex.swift
+++ b/Sources/NeAntik/WorkplaceHomeIndex.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+struct WorkplaceHomeIndex: Equatable, Sendable {
+    let orderedActiveProfiles: [BrowserProfile]
+    let unfiledProfileIDs: Set<UUID>
+    let untaggedProfileIDs: Set<UUID>
+
+    init(
+        profiles: [BrowserProfile],
+        organization: ProfileOrganizationState
+    ) {
+        let activeProfiles = profiles.filter { !$0.isArchived }
+        orderedActiveProfiles = activeProfiles.sorted { lhs, rhs in
+            if lhs.isPinned != rhs.isPinned { return lhs.isPinned }
+            let left = lhs.lastLaunchedAt ?? lhs.createdAt
+            let right = rhs.lastLaunchedAt ?? rhs.createdAt
+            if left != right { return left > right }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+        unfiledProfileIDs = Set(activeProfiles.compactMap { profile in
+            organization.folder(withID: organization.folderID(forProfileID: profile.id)) == nil
+                ? profile.id
+                : nil
+        })
+        untaggedProfileIDs = Set(activeProfiles.compactMap { profile in
+            profile.tags.isEmpty ? profile.id : nil
+        })
+    }
+
+    func resolve(
+        search: String,
+        operational: ProfileOperationalProjection,
+        limit: Int = 24,
+        revealProfileID: UUID? = nil
+    ) -> WorkplaceHomeProjection {
+        let query = search.trimmingCharacters(in: .whitespacesAndNewlines)
+        let matches = orderedActiveProfiles.filter { profile in
+            query.isEmpty || ([profile.name, profile.note] + profile.tags).contains {
+                $0.localizedStandardContains(query)
+            }
+        }
+        let summary = WorkplaceHomeSummary(
+            activeCount: orderedActiveProfiles.count,
+            runningCount: operational.runningProfileIDs.count,
+            attentionCount: operational.attentionProfileIDs.count,
+            unfiledCount: unfiledProfileIDs.count,
+            untaggedCount: untaggedProfileIDs.count
+        )
+        var quickMatches: [WorkplaceHomeQuickFilter: [BrowserProfile]] = Dictionary(
+            uniqueKeysWithValues: WorkplaceHomeQuickFilter.allCases.map { ($0, []) }
+        )
+        for profile in matches {
+            quickMatches[.all, default: []].append(profile)
+            if operational.runningProfileIDs.contains(profile.id) {
+                quickMatches[.running, default: []].append(profile)
+            }
+            if operational.attentionProfileIDs.contains(profile.id) {
+                quickMatches[.attention, default: []].append(profile)
+            }
+            if unfiledProfileIDs.contains(profile.id) {
+                quickMatches[.unfiled, default: []].append(profile)
+            }
+            if untaggedProfileIDs.contains(profile.id) {
+                quickMatches[.untagged, default: []].append(profile)
+            }
+        }
+        return WorkplaceHomeProjection(
+            profiles: WorkplaceHomeProjection.visibleProfiles(
+                matches: matches, limit: limit, revealProfileID: revealProfileID
+            ),
+            matchCount: matches.count,
+            summary: summary,
+            matchesByQuickFilter: quickMatches
+        )
+    }
+}
+
+@MainActor
+final class WorkplaceHomeStateResolver {
+    private var profileRevision: UInt64?
+    private var index: WorkplaceHomeIndex?
+    private var processRevision: UInt64?
+    private var healthRecords: [UUID: ProxyHealthRecord]?
+    private var operational: ProfileOperationalProjection?
+
+    func resolve(
+        profileRevision requestedProfileRevision: UInt64,
+        processRevision requestedProcessRevision: UInt64,
+        healthRecords requestedHealthRecords: [UUID: ProxyHealthRecord],
+        profiles: [BrowserProfile],
+        organization: ProfileOrganizationState,
+        search: String,
+        revealProfileID: UUID?,
+        processState: (UUID) -> BrowserProfileProcessState,
+        proxyHealth: (BrowserProfile) -> ProxyHealthState?
+    ) -> WorkplaceHomeProjection {
+        let currentIndex: WorkplaceHomeIndex
+        if profileRevision == requestedProfileRevision, let index {
+            currentIndex = index
+        } else {
+            let resolved = WorkplaceHomeIndex(
+                profiles: profiles,
+                organization: organization
+            )
+            profileRevision = requestedProfileRevision
+            index = resolved
+            processRevision = nil
+            healthRecords = nil
+            operational = nil
+            currentIndex = resolved
+        }
+        let currentOperational: ProfileOperationalProjection
+        if processRevision == requestedProcessRevision,
+           healthRecords == requestedHealthRecords,
+           let operational
+        {
+            currentOperational = operational
+        } else {
+            let resolved = ProfileOperationalProjection.resolve(
+                profiles: currentIndex.orderedActiveProfiles,
+                processState: processState,
+                proxyHealth: proxyHealth
+            )
+            processRevision = requestedProcessRevision
+            healthRecords = requestedHealthRecords
+            operational = resolved
+            currentOperational = resolved
+        }
+        return currentIndex.resolve(
+            search: search,
+            operational: currentOperational,
+            revealProfileID: revealProfileID
+        )
+    }
+}

--- a/Sources/NeAntik/WorkplaceMenu.swift
+++ b/Sources/NeAntik/WorkplaceMenu.swift
@@ -31,7 +31,7 @@ struct WorkplaceMenu: View {
     @ObservedObject var navigation: WorkplaceNavigation
 
     private var places: [BrowserProfile] {
-        WorkplaceHomeProjection.resolve(profiles: store.profiles, search: "", limit: 8).profiles
+        WorkplaceMenuProjection.recentPlaces(profiles: store.profiles)
     }
 
     var body: some View {

--- a/Sources/NeAntik/WorkplaceMenuProjection.swift
+++ b/Sources/NeAntik/WorkplaceMenuProjection.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// A lightweight menu-only view. Unlike Home, it never reads process or proxy
+/// state because the menu needs only recent local places.
+enum WorkplaceMenuProjection {
+    static func recentPlaces(
+        profiles: [BrowserProfile],
+        limit: Int = 8
+    ) -> [BrowserProfile] {
+        Array(
+            profiles
+                .lazy
+                .filter { !$0.isArchived }
+                .sorted(by: areInMenuOrder)
+                .prefix(max(0, limit))
+        )
+    }
+
+    private static func areInMenuOrder(
+        _ lhs: BrowserProfile,
+        _ rhs: BrowserProfile
+    ) -> Bool {
+        if lhs.isPinned != rhs.isPinned { return lhs.isPinned }
+        let left = lhs.lastLaunchedAt ?? lhs.createdAt
+        let right = rhs.lastLaunchedAt ?? rhs.createdAt
+        if left != right { return left > right }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+}

--- a/Tests/NeAntikTests/ProfileTagEditorTests.swift
+++ b/Tests/NeAntikTests/ProfileTagEditorTests.swift
@@ -198,6 +198,23 @@ struct ProfileTagEditorTests {
     #expect(editor.folders == [folder])
     #expect(editor.suggestedTags == ["qa", "demo"])
   }
+
+  @MainActor
+  @Test
+  func tagFocusOpensTheAdvancedEditorSection() {
+    #expect(ProfileEditorInitialPresentation.showsAdvancedOptions(
+      initialFocus: .tags,
+      requested: false
+    ))
+    #expect(ProfileEditorInitialPresentation.showsAdvancedOptions(
+      initialFocus: .startURL,
+      requested: false
+    ))
+    #expect(!ProfileEditorInitialPresentation.showsAdvancedOptions(
+      initialFocus: .name,
+      requested: false
+    ))
+  }
 }
 
 private struct ProfileTagEditorKeychainBackend: KeychainBackend {

--- a/Tests/NeAntikTests/RuntimeResolutionStateTests.swift
+++ b/Tests/NeAntikTests/RuntimeResolutionStateTests.swift
@@ -1,0 +1,13 @@
+import Testing
+@testable import NeAntik
+
+struct RuntimeResolutionStateTests {
+    @Test func onlyTheNewestResolutionMayCommit() {
+        var state = RuntimeResolutionState()
+        let first = state.begin()
+        let second = state.begin()
+
+        #expect(!state.isCurrent(first))
+        #expect(state.isCurrent(second))
+    }
+}

--- a/Tests/NeAntikTests/WorkplaceHomeTests.swift
+++ b/Tests/NeAntikTests/WorkplaceHomeTests.swift
@@ -128,6 +128,50 @@ struct WorkplaceHomeTests {
         #expect(proxyReads == places.count)
     }
 
+    @Test func quickViewCountsRespectTheCurrentSearch() {
+        let running = BrowserProfile(name: "Running")
+        let stopped = BrowserProfile(name: "Stopped")
+        let result = WorkplaceHomeProjection.resolve(
+            profiles: [running, stopped],
+            search: "Stopped",
+            processState: { $0 == running.id ? .managed : .stopped }
+        )
+
+        #expect(result.summary.runningCount == 1)
+        #expect(result.matchCount(for: .running) == 0)
+        #expect(result.profiles(for: .running).isEmpty)
+    }
+
+    @MainActor @Test func homeResolverDoesNotReinspectOrResortForSearchOnlyUpdates() {
+        let places = (0..<10_000).map { index in
+            BrowserProfile(
+                name: "Place \(index)",
+                createdAt: Date(timeIntervalSince1970: TimeInterval(index))
+            )
+        }
+        let resolver = WorkplaceHomeStateResolver()
+        var processReads = 0
+        var proxyReads = 0
+        let resolve: (String) -> WorkplaceHomeProjection = { search in
+            resolver.resolve(
+                profileRevision: 1,
+                processRevision: 1,
+                healthRecords: [:],
+                profiles: places,
+                organization: .empty,
+                search: search,
+                revealProfileID: nil,
+                processState: { _ in processReads += 1; return .stopped },
+                proxyHealth: { _ in proxyReads += 1; return nil }
+            )
+        }
+
+        #expect(resolve("Place 1").matchCount > 0)
+        #expect(resolve("Place 2").matchCount > 0)
+        #expect(processReads == places.count)
+        #expect(proxyReads == places.count)
+    }
+
     @Test func openNeverStopsRunningPlaceEvenWithoutRuntime() {
         for state in [BrowserProfileProcessState.managed, .externalVerified, .externalManualOnly] {
             let result = WorkplaceOpenPresentation.resolve(state: state, archived: false, runtime: .missing)

--- a/Tests/NeAntikTests/WorkplaceMenuProjectionTests.swift
+++ b/Tests/NeAntikTests/WorkplaceMenuProjectionTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import NeAntik
+
+struct WorkplaceMenuProjectionTests {
+    @Test func recentPlacesExcludeArchiveAndMatchHomeOrder() {
+        let pinned = BrowserProfile(
+            name: "Pinned",
+            isPinned: true,
+            createdAt: Date(timeIntervalSince1970: 1)
+        )
+        let recent = BrowserProfile(
+            name: "Recent",
+            lastLaunchedAt: Date(timeIntervalSince1970: 3)
+        )
+        let older = BrowserProfile(
+            name: "Older",
+            lastLaunchedAt: Date(timeIntervalSince1970: 2)
+        )
+        let archived = BrowserProfile(name: "Archive", isArchived: true)
+        let profiles = [older, archived, recent, pinned]
+
+        #expect(WorkplaceMenuProjection.recentPlaces(profiles: profiles) == [pinned, recent, older])
+        #expect(WorkplaceMenuProjection.recentPlaces(profiles: profiles, limit: 2) == [pinned, recent])
+    }
+}

--- a/scripts/tests/test_responsive_ui_contract.py
+++ b/scripts/tests/test_responsive_ui_contract.py
@@ -603,7 +603,7 @@ class ResponsiveUIContractTests(unittest.TestCase):
         for condition in [
             "workspaceSheetRequest != nil", "showingReleaseFingerprintAudit",
             "showingDeleteConfirmation", "folderPendingDelete != nil",
-            "forceStopRequest != nil", "launchPreparationFailure != nil",
+            "forceStopRequest != nil", "launchIssue != nil",
             "workspaceAlert != nil",
         ]:
             self.assertIn(condition, modal_guard)

--- a/scripts/verify-native-swift-shard.sh
+++ b/scripts/verify-native-swift-shard.sh
@@ -32,6 +32,7 @@ case "$SHARD" in
       BulkProxyRunProgressTests
       DisplayDateFormattingTests
       RussianCountTests
+      RuntimeResolutionStateTests
       UserNoticeTests
     )
     ;;
@@ -93,6 +94,7 @@ case "$SHARD" in
       ProxyTestOperationRegistryTests
       ProxyTesterTests
       ResponsiveLayoutRenderTests
+      WorkplaceMenuProjectionTests
       ProfileInspectorPolicyTests
       ProfileRowLayoutTests
       ProfileRowPresentationTests


### PR DESCRIPTION
## What changed

- Reuse the local Home index and operational state during search; counts now match the visible result.
- Build recent-workplace menu data without the full Home projection.
- Prevent stale runtime resolution from replacing a newer result.
- Open tags with the requested advanced editor section and keyboard focus.
- Persist proxy-health data through an owner-only descriptor-bound durable replacement path.

## Validation

- `./scripts/verify-native-swift-tests.sh`
- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -q` (699 passed, 1 skipped)
- `python3 scripts/audit-source-budgets.py`
- `python3 scripts/audit-git-history-secrets.py`

Direct Distribution only; no App Store workflow.