### PR TITLE
Harden fingerprint audit empty selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # NeAntik changelog
 
+## Direct 0.5.5 (35) — September 11, 2026
+
+- Проверка отпечатка безопасно открывается даже при пустом или ещё не загруженном списке профилей.
+- Расширенные настройки и диагностика остаются скрытыми до явного запроса; основной сценарий не изменён.
+
 ## Direct 0.5.4 (34) — September 10, 2026
 
 - Make Home search faster on large local workplace lists: the sorted index and

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -23,11 +23,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.4</string>
+	<string>0.5.5</string>
 	<key>CFBundleSignature</key>
 	<string>NANT</string>
 	<key>CFBundleVersion</key>
-	<string>34</string>
+	<string>35</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/NeAntik/FingerprintAuditView.swift
+++ b/Sources/NeAntik/FingerprintAuditView.swift
@@ -83,14 +83,12 @@ struct FingerprintAuditView: View {
         self.onReport = onReport
         isReleaseAudit = releaseContext != nil
 
-        let first =
-            profiles.first(where: { $0.id == initialFirstID }) ??
-            profiles.first!
-        let second =
-            profiles.first(where: { $0.id != first.id }) ??
-            first
-        _firstID = State(initialValue: first.id)
-        _secondID = State(initialValue: second.id)
+        let firstID = profiles.first(where: { $0.id == initialFirstID })?.id ??
+            profiles.first?.id ?? UUID()
+        let secondID = profiles.first(where: { $0.id != firstID })?.id ??
+            firstID
+        _firstID = State(initialValue: firstID)
+        _secondID = State(initialValue: secondID)
         _coordinator = StateObject(
             wrappedValue: FingerprintAuditCoordinator(
                 paths: paths,


### PR DESCRIPTION
Protect FingerprintAuditView from empty profile arrays by removing a force unwrap. Bump Direct release metadata to 0.5.5 (35) and document the fix. Native Swift suite: 784 tests passed.